### PR TITLE
New module for custom tokens

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -40,6 +40,7 @@ module:
   helfi_api_base: 0
   image: 0
   image_style_quality: 0
+  infofinland_common: 0
   infofinland_migrate: 0
   infofinland_municipality_selection: 0
   jsonapi: 0

--- a/conf/cmi/pathauto.pattern.page_content_pattern.yml
+++ b/conf/cmi/pathauto.pattern.page_content_pattern.yml
@@ -9,16 +9,16 @@ _core:
 id: page_content_pattern
 label: 'Page content pattern'
 type: 'canonical_entities:node'
-pattern: '[node:menu-link:parents:join-path]/[node:field_url]'
+pattern: '[node:menu-link:parents:join-path-en]/[node:field_url]'
 selection_criteria:
-  f3799a81-6b6b-4456-bdbe-a21c2e223659:
+  92202df0-aea6-4468-8f85-94884e53d334:
     id: node_type
     bundles:
       page: page
     negate: false
     context_mapping:
       node: node
-    uuid: f3799a81-6b6b-4456-bdbe-a21c2e223659
+    uuid: 92202df0-aea6-4468-8f85-94884e53d334
 selection_logic: and
 weight: -5
 relationships: {  }

--- a/conf/cmi/pathauto.settings.yml
+++ b/conf/cmi/pathauto.settings.yml
@@ -49,5 +49,6 @@ safe_tokens:
   - login-url
   - url
   - url-brief
+  - join-path-en
 _core:
   default_config_hash: Ne69dMMwlFhwkLqsxAPs20dQCSMk3iibq1pr5qrHf2I

--- a/public/modules/custom/infofinland_common/infofinland_common.info.yml
+++ b/public/modules/custom/infofinland_common/infofinland_common.info.yml
@@ -1,0 +1,5 @@
+name: InfoFinland Common
+description: 'Custom functionality'
+package: 'Custom'
+type: module
+core_version_requirement: ^8 || ^9

--- a/public/modules/custom/infofinland_common/infofinland_common.module
+++ b/public/modules/custom/infofinland_common/infofinland_common.module
@@ -1,0 +1,7 @@
+<?php
+
+/**
+ * @file
+ * Infofinland Common module.
+ */
+

--- a/public/modules/custom/infofinland_common/infofinland_common.tokens.inc
+++ b/public/modules/custom/infofinland_common/infofinland_common.tokens.inc
@@ -1,0 +1,56 @@
+<?php
+
+/**
+ * @file
+ * Token integration for the Infofinland common module.
+ */
+
+use Drupal\Core\Render\BubbleableMetadata;
+
+/**
+ * Implements hook_token_info()
+ */
+
+function infofinland_common_token_info() {
+  $info = [];
+
+  $info['tokens']['array']['join-path-en'] = array(
+    'name' => t('Menu link parents en'),
+    'description' => t('Menu link parents in english'),
+  );
+
+  return $info;
+}
+
+
+/**
+ * Implements hook_tokens()
+ *
+ * Custom token for getting menu path in english.
+ */
+
+function infofinland_common_tokens($type, $tokens, array $data, array $options, BubbleableMetadata $bubbleable_metadata) {
+  $replacements = [];
+
+  if ($type == 'array' && !empty($data['array'])) {
+    $array = $data['array'];
+
+    foreach ($tokens as $name => $original) {
+      switch ($name) {
+        case 'join-path-en':
+          $values = [];
+          foreach (token_element_children($array) as $key) {
+            $uuid = substr($key, strlen('menu_link_content:'));
+            $entity = \Drupal::service('entity.repository')->loadEntityByUuid('menu_link_content', $uuid);
+            $title = $entity->hasTranslation('en') ? $entity->getTranslation('en')->getTitle() : $entity->getTitle();
+            $value = \Drupal::service('pathauto.alias_cleaner')->cleanString($title, $options);
+            $values[] = $value;
+          }
+          $replacements[$original] = implode('/', $values);
+          break;
+      }
+    }
+  }
+
+  return $replacements;
+}


### PR DESCRIPTION
Add new module for common custom code
Add new token for generating full english paths.

**How to test**
```
make build
make shell
drush en infofinland_common
drush cim -y
drush cr
```

Go to a page in different language than english that has parents in menu tree. Save it. Check that every part of url after language prefix is in english.
