### PR TITLE
IFU-858 - fixing error

### DIFF
--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -847,7 +847,6 @@ display:
             zh: zh
             fa: fa
             ar: ar
-            so: so
           group: 1
           exposed: true
           expose:
@@ -870,6 +869,7 @@ display:
               content_producer: '0'
               municipal_editor: '0'
               nextjs: '0'
+              infofinland_admin: '0'
             reduce: true
           is_grouped: false
           group_info:
@@ -1089,6 +1089,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      rendering_language: '***LANGUAGE_entity_default***'
       display_extenders:
         metatag_display_extender:
           metatags: {  }
@@ -1110,7 +1111,6 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
-        - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -231,3 +231,9 @@ if ($env = getenv('APP_ENV')) {
 //if (file_exists(__DIR__ . '/' . 'local' . '.settings.php')) {
 //  include __DIR__ . '/' . 'local' . '.settings.php';
 //}
+
+// Automatically generated include for settings managed by ddev.
+$ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
+if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
+  require $ddev_settings;
+}


### PR DESCRIPTION
A previous changeset broke the content listing admin UI view. This should fix it. 

To test, run `cim` and `cr` kind of stuff and check /admin/content

This fix was based on this thread: https://www.drupal.org/project/drupal/issues/2917327#comment-15032240
Confirmed, last year they removed Somali language and added Ukraine. So this was it.