### PR TITLE
IFU-872: bugfix/IFU-872: Changed the variable name

### DIFF
--- a/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
+++ b/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
@@ -38,7 +38,7 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $entityManager;
+  protected $entityTypeManager;
 
   /**
    * The logger.


### PR DESCRIPTION
Found out that there might be a bug on the broken link checker source code. 

So I changed the Entity type manager variable name from `entityManager` to `entityTypeManager`, because the constructor uses `entityTypeManager`  and also it uses the `entityTypeManager` variable name for the rest of the code. 

So I think there was a mismatch between these two variable names. So if you look at the source code on lines 41, 69, 110 and 115 you'll see what the problem was.  So this may have an effect for the cron runs and why working links gets flagged as a broken links.