### PR TITLE
IFU-875: bugfix/IFU-875: Changed field label from 'Last updated by' t…

### DIFF
--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -244,7 +244,7 @@ display:
           entity_type: user
           entity_field: name
           plugin_id: field
-          label: 'Last updated by'
+          label: Päivittänyt
           exclude: false
           alter:
             alter_text: false


### PR DESCRIPTION
First run the following commands, `drush cim` and `drush cr` . 

As the ticket explains it, there was one field label wrong in the content page or content view. The Last updated by -column says Tekijä, it should say Päivittänyt. 

Actually there was a problem with my local, that I couldn't reproduce the problem. I couldn't see the Tekijä label on the Last updated by column. For me the label was always Last updated by. But I changed the label value to Päivittänyt. 

So to test this, go to content page and see if the column label has changed to Päivittänyt. Also we might need to adjust the translations, if necessary. 