### PR TITLE
Bugfix/IFU-875 content list label translations

### DIFF
--- a/conf/cmi/language/es/webform.webform_options.days.yml
+++ b/conf/cmi/language/es/webform.webform_options.days.yml
@@ -1,0 +1,1 @@
+label: Days

--- a/conf/cmi/language/es/webform.webform_options.days.yml
+++ b/conf/cmi/language/es/webform.webform_options.days.yml
@@ -1,1 +1,0 @@
-label: Days

--- a/conf/cmi/language/fi/views.view.content.yml
+++ b/conf/cmi/language/fi/views.view.content.yml
@@ -7,7 +7,7 @@ display:
         type:
           label: Sisältötyyppi
         name:
-          label: Tekijä
+          label: Päivittänyt
         status:
           label: Tila
           settings:
@@ -17,6 +17,12 @@ display:
           label: Päivitetty
         operations:
           label: Toimenpiteet
+        langcode:
+          label: Kieli
+        moderation_state:
+          label: Julkaisutila
+        field_page_name:
+          label: Nimi
       title: Sisältö
       pager:
         options:
@@ -24,14 +30,11 @@ display:
             next: 'Seuraava ›'
             previous: '‹ Edellinen'
             first: '« Ensimmäinen'
-            last: 'Last »'
       exposed_form:
         options:
           submit_button: Suodatus
           reset_button_label: Palauta
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
       empty:
         area_text_custom:
           content: 'Ei sisältöä.'

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -114,7 +114,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: Nimi
+          label: Name
           exclude: false
           alter:
             alter_text: false


### PR DESCRIPTION
Corrected the translations on the Content listing.

To test, go to the content listing `admin/content` - verify that the translations of the table titles are correct.
- Check english and finnish
- try changing the language suffix in the URL
- Try changing the language settings in your profile to see that forcing the language works correctly.