### PR TITLE
IFU-859: Fix the logical error on the source code

### DIFF
--- a/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
+++ b/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
@@ -105,7 +105,7 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
       // This happens for example following reasons, 
       // cURL error 28: Operation timed out after 30001 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) 
       // If this happens, the broken link status gets an empty value.
-      $this->logger->warning('Checking URL failed: parent_id: @parent_id , id: @id ,  url: @url - @message ', $logger_params);
+      $this->logger->warning('Checking cURL status failed: parent_id: @parent_id , id: @id ,  url: @url - @message ', $logger_params);
       return;
     }
 
@@ -120,8 +120,8 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
         $languageLinkParagraph->save();
       }
 
-      $logger_params['@code'] = $code;
-      $this->logger->warning('Checking URL status passed: parent_id: @parent_id , id: @id , url: @url - code: @code ', $logger_params);
+      // $logger_params['@code'] = $code;
+      // $this->logger->warning('Checking URL status passed: parent_id: @parent_id , id: @id , url: @url - code: @code ', $logger_params);
     }
     else {
       if ($linkNode = $this->entityTypeManager->getStorage('node')->load($response->parent_id)) {

--- a/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
+++ b/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
@@ -108,6 +108,20 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
 
     if ($code === 200) {
       if ($linkNode = $this->entityTypeManager->getStorage('node')->load($response->parent_id)) {
+        $linkNode->set('field_broken_link', false);
+        $linkNode->save();
+      }
+
+      if ($languageLinkParagraph = $this->entityTypeManager->getStorage('paragraph')->load($response->id)) {
+        $languageLinkParagraph->set('field_broken_link', false);
+        $languageLinkParagraph->save();
+      }
+
+      $logger_params['@code'] = $code;
+      $this->logger->warning('Checking URL status passed: id: @id , parent_id: @parent_id, url: @url - code: @code ', $logger_params);
+    }
+    else {
+      if ($linkNode = $this->entityTypeManager->getStorage('node')->load($response->parent_id)) {
         $linkNode->set('field_broken_link', true);
         $linkNode->save();
       }
@@ -115,9 +129,8 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
       if ($languageLinkParagraph = $this->entityTypeManager->getStorage('paragraph')->load($response->id)) {
         $languageLinkParagraph->set('field_broken_link', true);
         $languageLinkParagraph->save();
-      }
-    }
-    else {
+      }  
+
       $logger_params['@code'] = $code;
       $this->logger->warning('Checking URL status failed: id: @id , parent_id: @parent_id, url: @url - code: @code ', $logger_params);
     }


### PR DESCRIPTION
The ticket can be found below:

[IFU-859](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IFU/boards/198?modal=detail&selectedIssue=IFU-859)

Then run the following commands, git pull and drush cr.

What this ticket or fix does, it fixes one of the logical errors on the broken link checkers source code.

To test this, you should first enable the dblog module and run the cron (multiple times) and then see the results of the cron run on dblog. Now the results should be more reasonable. Another thing that you can check is the linkkipankki page, where you can see which broken links are marked as true and false. After cron run, the true values should be decreasing and the false values should be increasing.  

[IFU-859]: https://helsinkisolutionoffice.atlassian.net/browse/IFU-859?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ