### PR TITLE
IFU-792: Did a manual hack to get the indicator colors working

### DIFF
--- a/conf/cmi/environment_indicator.switcher.development.yml
+++ b/conf/cmi/environment_indicator.switcher.development.yml
@@ -7,5 +7,5 @@ description: null
 name: Development
 weight: '4'
 url: 'https://edit-infofinland.dev.hel.ninja/'
-fg_color: '#d0d0d0'
+fg_color: '#000000'
 bg_color: '#33d17a'

--- a/conf/cmi/environment_indicator.switcher.stage.yml
+++ b/conf/cmi/environment_indicator.switcher.stage.yml
@@ -7,5 +7,5 @@ description: null
 name: Stage
 weight: '2'
 url: 'https://infofinland-edit.stage.hel.ninja/'
-fg_color: '#d0d0d0'
+fg_color: '#000000'
 bg_color: '#3584e4'

--- a/conf/cmi/environment_indicator.switcher.test.yml
+++ b/conf/cmi/environment_indicator.switcher.test.yml
@@ -7,5 +7,5 @@ description: null
 name: Test
 weight: '3'
 url: 'https://edit-infofinland.test.hel.ninja/'
-fg_color: '#d0d0d0'
+fg_color: '#000000'
 bg_color: '#ed333b'

--- a/public/sites/default/env.indicator.settings.php
+++ b/public/sites/default/env.indicator.settings.php
@@ -1,0 +1,27 @@
+<?php 
+/**
+ * The UI for environment indicator is broken, so we have to do this instead.
+ * See more info, https://www.drupal.org/project/environment_indicator/issues/2224983
+ */
+switch ($_SERVER['HTTP_HOST']) {
+	case 'edit.infofinland.fi/':
+		$config['environment_indicator.indicator']['bg_color'] = '#ffffff';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Production';
+		$break;
+	case 'infofinland-edit.stage.hel.ninja':
+		$config['environment_indicator.indicator']['bg_color'] = '#3584e4';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Stage';
+		$break;
+	case 'edit-infofinland.test.hel.ninja':
+		$config['environment_indicator.indicator']['bg_color'] = '#ed333b';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Test';
+		$break;
+	case 'edit-infofinland.dev.hel.ninja':
+		$config['environment_indicator.indicator']['bg_color'] = '#33d17a';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Development';
+		break;
+}

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -237,3 +237,9 @@ $ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
 if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
   require_once $ddev_settings; // TODO Check this if something stops working, `require`.
 }
+
+// Environment indicator hack, see the file for more info
+$env_indicator_settings = dirname(__FILE__) . '/env.indicator.settings.php';
+if (file_exists($env_indicator_settings)) {
+  require_once $env_indicator_settings;
+}


### PR DESCRIPTION
First run the following commands, `git pull` , `drush cr` , `drush cim` and `drush cr` again. 

As you can see from here, [Doesn't change the color of the toolbar](https://www.drupal.org/project/environment_indicator/issues/2857791). People has been having problems with the colors. Also the suggested Environment indicator UI  module didn't work. So we had to do things manually with the `settings.php` file.

So I made some changes. I created a new file called `env.indicator.settings.php` and included (required) that on `settings.php` file. In the env.indicator.settings file, there are the environments and colors and they should match with the config files. Unfortunately, when I edited the config files the production config didn't have any changes, but it's kinda obvious what the right values would be. 

Also the testing part is quite a tricky, because you can't actually test this on your local. Because the new settings files needs to get merged for example develope and after that you need to login into the develope and see if it's green. 

This is one of those PR's, that should work, but not 100 % sure that it will. 