### PR TITLE
IFU-792: Added the missing config, so logged in users can see the env indicator

### DIFF
--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -3,9 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - environment_indicator.switcher.development
+    - environment_indicator.switcher.production
+    - environment_indicator.switcher.stage
+    - environment_indicator.switcher.test
     - filter.format.full_html
     - filter.format.simple_html
   module:
+    - environment_indicator
     - filter
     - legal
     - media
@@ -19,6 +24,11 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
+  - 'access environment indicator'
+  - 'access environment indicator development'
+  - 'access environment indicator production'
+  - 'access environment indicator stage'
+  - 'access environment indicator test'
   - 'use text format full_html'
   - 'use text format simple_html'
   - 'view Terms and Conditions'


### PR DESCRIPTION
First run the following commands, `git pull` , `drush cr` , `drush cim` and `drush cr` again.

Added or edited the missing config so logged in users can see the environment indicator. 

To test, log in to the BE and go to `/en/admin/people/permissions/authenticated` . Scroll down to Environment Indicator and see the settings, the settings should be as follow.

![Screenshot 2023-08-21 at 20-21-26 Edit role InfoFinland](https://github.com/City-of-Helsinki/drupal-infofinland/assets/131336019/3d5ec4ff-2572-40dd-a6bd-73e1f12824c2)
