### PR TITLE
Feature/IFU-873 gdpr log

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "drupal/core-composer-scaffold": "^9.4",
         "drupal/core-recommended": "^9.4",
         "drupal/crop": "^2.2",
+        "drupal/environment_indicator": "^4.0",
         "drupal/hdbt": "^1.0",
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_api_base": "^2.0",
@@ -93,7 +94,8 @@
                 "3101344 - Cannot save translated nodes after upgrading to 8.8 due to invalid path": "https://www.drupal.org/files/issues/2021-11-15/drupal-path-error-when-not-visible-3101344-81-D9.patch",
                 "2838602 - [PP-2] Optimize CEB::hasTranslationChanges by caching its result and serving subsequent calls from the result cache - big performance boost": "https://www.drupal.org/files/issues/2019-09-16/2838602-54.patch",
                 "3007031 - hasTranslationChanges on multiple languages outside of saving process is costly": "https://git.drupalcode.org/project/drupal/-/merge_requests/197.diff",
-                "2815779 - Deleting a translation leaves behind orphaned revisions": "https://www.drupal.org/files/issues/2019-11-25/8x9x-2815779-19.patch"
+                "2815779 - Deleting a translation leaves behind orphaned revisions": "https://www.drupal.org/files/issues/2019-11-25/8x9x-2815779-19.patch",
+                "3301239 - PoStreamReader::readLine() throws an error on module install": "https://www.drupal.org/files/issues/2023-01-17/drupal_core-PoStreamReader_readLine_throws_an_error_on_module_install-3301239-7.patch"
             },
             "drupal/ctools": {
                 "3300682 - The context is not a valid context.": "https://www.drupal.org/files/issues/2022-08-03/3300682-50.patch"

--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
         "drupal/core-recommended": "^9.4",
         "drupal/crop": "^2.2",
         "drupal/environment_indicator": "^4.0",
+        "drupal/filelog": "^2.1",
         "drupal/hdbt": "^1.0",
         "drupal/hdbt_admin": "^1.0",
         "drupal/helfi_api_base": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ce965cf6ce8c13b7e149e64fb79d70fe",
+    "content-hash": "9c2aa5d9bd8fb8c218dcc966da2a51c0",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2868,6 +2868,10 @@
                     "role": "Maintainer"
                 },
                 {
+                    "name": "lhangea",
+                    "homepage": "https://www.drupal.org/user/2743803"
+                },
+                {
                     "name": "miro_dietiker",
                     "homepage": "https://www.drupal.org/user/227761"
                 },
@@ -2893,6 +2897,68 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/diff",
                 "issues": "https://www.drupal.org/project/issues/diff"
+            }
+        },
+        {
+            "name": "drupal/dynamic_entity_reference",
+            "version": "3.0.0-beta1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/dynamic_entity_reference.git",
+                "reference": "3.0.0-beta1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/dynamic_entity_reference-3.0.0-beta1.zip",
+                "reference": "3.0.0-beta1",
+                "shasum": "602c65515d60ac87ac88b4e8900f1ddb861cde49"
+            },
+            "require": {
+                "drupal/core": "^9.3 || ^10",
+                "php": ">=8.0"
+            },
+            "require-dev": {
+                "mglaman/phpstan-drupal": "^1.1",
+                "phpstan/phpstan": "^1.1",
+                "phpstan/phpstan-deprecation-rules": "^1.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "3.0.0-beta1",
+                    "datestamp": "1663511602",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Beta releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Lee Rowlands",
+                    "homepage": "https://www.drupal.org/u/larowlan",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Jibran Ijaz",
+                    "homepage": "https://www.drupal.org/u/jibran",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "larowlan",
+                    "homepage": "https://www.drupal.org/user/395439"
+                }
+            ],
+            "description": "Provides a field that allows an entity-reference field to reference more than one entity type.",
+            "homepage": "http://drupal.org/project/dynamic_entity_reference",
+            "support": {
+                "source": "http://cgit.drupalcode.org/dynamic_entity_reference",
+                "issues": "http://drupal.org/project/dynamic_entity_reference",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
             }
         },
         {
@@ -3408,6 +3474,54 @@
             }
         },
         {
+            "name": "drupal/environment_indicator",
+            "version": "4.0.14",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/environment_indicator.git",
+                "reference": "4.0.14"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/environment_indicator-4.0.14.zip",
+                "reference": "4.0.14",
+                "shasum": "ff4fe11fcd5fa08b7ba7a451302cf93e5f68449c"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "4.0.14",
+                    "datestamp": "1674120945",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "e0ipso",
+                    "homepage": "https://www.drupal.org/user/550110"
+                },
+                {
+                    "name": "mrfelton",
+                    "homepage": "https://www.drupal.org/user/305669"
+                }
+            ],
+            "description": "Adds a color indicator for the different environments.",
+            "homepage": "https://www.drupal.org/project/environment_indicator",
+            "support": {
+                "source": "https://git.drupalcode.org/project/environment_indicator"
+            }
+        },
+        {
             "name": "drupal/eu_cookie_compliance",
             "version": "1.19.0",
             "source": {
@@ -3520,6 +3634,10 @@
             ],
             "authors": [
                 {
+                    "name": "Dave Reid",
+                    "homepage": "https://www.drupal.org/user/53892"
+                },
+                {
                     "name": "dawehner",
                     "homepage": "https://www.drupal.org/user/99340"
                 },
@@ -3546,6 +3664,10 @@
                 {
                     "name": "joseph.olstad",
                     "homepage": "https://www.drupal.org/user/1321830"
+                },
+                {
+                    "name": "matthand",
+                    "homepage": "https://www.drupal.org/user/171527"
                 },
                 {
                     "name": "mpotter",
@@ -4351,6 +4473,10 @@
                     "homepage": "https://www.drupal.org/user/17089"
                 },
                 {
+                    "name": "heddn",
+                    "homepage": "https://www.drupal.org/user/1463982"
+                },
+                {
                     "name": "Sam152",
                     "homepage": "https://www.drupal.org/user/1485048"
                 }
@@ -4475,12 +4601,12 @@
                     "homepage": "https://www.drupal.org/user/972218"
                 },
                 {
-                    "name": "kaythay",
-                    "homepage": "https://www.drupal.org/user/2182186"
-                },
-                {
                     "name": "oknate",
                     "homepage": "https://www.drupal.org/user/471638"
+                },
+                {
+                    "name": "podarok",
+                    "homepage": "https://www.drupal.org/user/116002"
                 },
                 {
                     "name": "ram4nd",
@@ -4801,6 +4927,72 @@
             }
         },
         {
+            "name": "drupal/linkchecker",
+            "version": "2.0.0-alpha1",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/linkchecker.git",
+                "reference": "2.0.0-alpha1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/linkchecker-2.0.0-alpha1.zip",
+                "reference": "2.0.0-alpha1",
+                "shasum": "ee0a058ca14a776284fdc3f784f5edac01a5ded3"
+            },
+            "require": {
+                "drupal/core": "^9.4 || ^10.0",
+                "drupal/dynamic_entity_reference": "^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "drupal/redirect": "^1.8"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "2.0.0-alpha1",
+                    "datestamp": "1674444668",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                },
+                "drush": {
+                    "services": {
+                        "drush.services.yml": "^10 || ^11"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "hass",
+                    "homepage": "https://www.drupal.org/u/hass"
+                },
+                {
+                    "name": "See other contributors",
+                    "homepage": "https://www.drupal.org/node/243795/committers"
+                },
+                {
+                    "name": "hass",
+                    "homepage": "https://www.drupal.org/user/85918"
+                },
+                {
+                    "name": "VladimirAus",
+                    "homepage": "https://www.drupal.org/user/673120"
+                }
+            ],
+            "description": "Periodically checks for broken links in node types, blocks and fields and reports the results.",
+            "homepage": "https://www.drupal.org/project/linkchecker",
+            "support": {
+                "source": "https://git.drupal.org/project/linkchecker.git",
+                "issues": "https://www.drupal.org/project/issues/linkchecker"
+            }
+        },
+        {
             "name": "drupal/linkit",
             "version": "6.0.0-beta3",
             "source": {
@@ -4845,6 +5037,10 @@
                 {
                     "name": "johnwebdev",
                     "homepage": "https://www.drupal.org/user/3331569"
+                },
+                {
+                    "name": "mark_fullmer",
+                    "homepage": "https://www.drupal.org/user/2612816"
                 }
             ],
             "description": "Linkit - Enriched linking experience",
@@ -5843,6 +6039,10 @@
                     "homepage": "https://www.drupal.org/user/959536"
                 },
                 {
+                    "name": "Rajab Natshah",
+                    "homepage": "https://www.drupal.org/user/1414312"
+                },
+                {
                     "name": "weseze",
                     "homepage": "https://www.drupal.org/user/417521"
                 }
@@ -6447,8 +6647,8 @@
                     "role": "Maintainer"
                 },
                 {
-                    "name": "benjy",
-                    "homepage": "https://www.drupal.org/user/1852732"
+                    "name": "JeroenT",
+                    "homepage": "https://www.drupal.org/user/2228934"
                 }
             ],
             "description": "Allows site administrators to grant some roles the authority to assign selected roles to users.",
@@ -6642,8 +6842,12 @@
             "authors": [
                 {
                     "name": "Christian Fritsch",
-                    "homepage": "https://www.drupal.org/user/2103716",
+                    "homepage": "https://www.drupal.org/user/157725",
                     "email": "christian.fritsch@burda.com"
+                },
+                {
+                    "name": "chr.fritsch",
+                    "homepage": "https://www.drupal.org/user/2103716"
                 }
             ],
             "description": "Integration with the select2 JavaScript library.",
@@ -6971,8 +7175,12 @@
                 },
                 {
                     "name": "Jack Over",
-                    "homepage": "https://www.drupal.org/user/252386",
+                    "homepage": "https://www.drupal.org/user/953390",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "takim",
+                    "homepage": "https://www.drupal.org/user/252386"
                 }
             ],
             "description": "Share current page to social media",
@@ -7496,20 +7704,20 @@
         },
         {
             "name": "drupal/varnish_purge",
-            "version": "2.1.0",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/varnish_purge.git",
-                "reference": "8.x-2.1"
+                "reference": "8.x-2.2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/varnish_purge-8.x-2.1.zip",
-                "reference": "8.x-2.1",
-                "shasum": "695eb7d81816e013e81d36207cfac162dd3cbe9f"
+                "url": "https://ftp.drupal.org/files/projects/varnish_purge-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "9fbddb71417113d58345d2fbe9d0a1aa9c5d5c36"
             },
             "require": {
-                "drupal/core": "^8 || ^9"
+                "drupal/core": "^8 || ^9 || ^10"
             },
             "require-dev": {
                 "drupal/purge": "*",
@@ -7519,8 +7727,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "8.x-2.1",
-                    "datestamp": "1615977068",
+                    "version": "8.x-2.2",
+                    "datestamp": "1681218333",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -7533,10 +7741,6 @@
             ],
             "authors": [
                 {
-                    "name": "MiSc",
-                    "homepage": "https://www.drupal.org/user/382892"
-                },
-                {
                     "name": "deadbeef",
                     "homepage": "https://www.drupal.org/user/93644"
                 },
@@ -7547,6 +7751,10 @@
                 {
                     "name": "littlethoughts",
                     "homepage": "https://www.drupal.org/user/2479724"
+                },
+                {
+                    "name": "MiSc",
+                    "homepage": "https://www.drupal.org/user/382892"
                 }
             ],
             "homepage": "https://www.drupal.org/project/varnish_purge",
@@ -7603,6 +7811,14 @@
                 {
                     "name": "entendu",
                     "homepage": "https://www.drupal.org/user/173461"
+                },
+                {
+                    "name": "fathima.asmat",
+                    "homepage": "https://www.drupal.org/user/3622664"
+                },
+                {
+                    "name": "tobiasb",
+                    "homepage": "https://www.drupal.org/user/183956"
                 }
             ],
             "description": "Select which roles should be able to see unpublished nodes.",
@@ -7758,10 +7974,6 @@
             ],
             "authors": [
                 {
-                    "name": "Nelson Alves",
-                    "homepage": "https://www.drupal.org/user/3557178"
-                },
-                {
                     "name": "dgaspara",
                     "homepage": "https://www.drupal.org/user/3557179"
                 },
@@ -7772,6 +7984,10 @@
                 {
                     "name": "joaomarques736",
                     "homepage": "https://www.drupal.org/user/3557181"
+                },
+                {
+                    "name": "nsalves",
+                    "homepage": "https://www.drupal.org/user/3557178"
                 }
             ],
             "description": "Allows retrieving webform elements and submitting webforms via REST",
@@ -15040,8 +15256,14 @@
             "version": "8.3.16",
             "source": {
                 "type": "git",
-                "url": "https://git.drupalcode.org/project/coder.git",
+                "url": "https://github.com/pfrenssen/coder.git",
                 "reference": "d6f6112e5e84ff4f6baaada223c93dadbd6d3887"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pfrenssen/coder/zipball/d6f6112e5e84ff4f6baaada223c93dadbd6d3887",
+                "reference": "d6f6112e5e84ff4f6baaada223c93dadbd6d3887",
+                "shasum": ""
             },
             "require": {
                 "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
@@ -17988,5 +18210,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9c2aa5d9bd8fb8c218dcc966da2a51c0",
+    "content-hash": "913d630cbab73a8a1da4ee2ce91fad1a",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2900,68 +2900,6 @@
             }
         },
         {
-            "name": "drupal/dynamic_entity_reference",
-            "version": "3.0.0-beta1",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/dynamic_entity_reference.git",
-                "reference": "3.0.0-beta1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/dynamic_entity_reference-3.0.0-beta1.zip",
-                "reference": "3.0.0-beta1",
-                "shasum": "602c65515d60ac87ac88b4e8900f1ddb861cde49"
-            },
-            "require": {
-                "drupal/core": "^9.3 || ^10",
-                "php": ">=8.0"
-            },
-            "require-dev": {
-                "mglaman/phpstan-drupal": "^1.1",
-                "phpstan/phpstan": "^1.1",
-                "phpstan/phpstan-deprecation-rules": "^1.0"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "3.0.0-beta1",
-                    "datestamp": "1663511602",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Beta releases are not covered by Drupal security advisories."
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Lee Rowlands",
-                    "homepage": "https://www.drupal.org/u/larowlan",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Jibran Ijaz",
-                    "homepage": "https://www.drupal.org/u/jibran",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "larowlan",
-                    "homepage": "https://www.drupal.org/user/395439"
-                }
-            ],
-            "description": "Provides a field that allows an entity-reference field to reference more than one entity type.",
-            "homepage": "http://drupal.org/project/dynamic_entity_reference",
-            "support": {
-                "source": "http://cgit.drupalcode.org/dynamic_entity_reference",
-                "issues": "http://drupal.org/project/dynamic_entity_reference",
-                "irc": "irc://irc.freenode.org/drupal-contribute"
-            }
-        },
-        {
             "name": "drupal/easy_breadcrumb",
             "version": "2.0.2",
             "source": {
@@ -4924,72 +4862,6 @@
             "homepage": "https://www.drupal.org/project/legal",
             "support": {
                 "source": "https://git.drupalcode.org/project/legal"
-            }
-        },
-        {
-            "name": "drupal/linkchecker",
-            "version": "2.0.0-alpha1",
-            "source": {
-                "type": "git",
-                "url": "https://git.drupalcode.org/project/linkchecker.git",
-                "reference": "2.0.0-alpha1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/linkchecker-2.0.0-alpha1.zip",
-                "reference": "2.0.0-alpha1",
-                "shasum": "ee0a058ca14a776284fdc3f784f5edac01a5ded3"
-            },
-            "require": {
-                "drupal/core": "^9.4 || ^10.0",
-                "drupal/dynamic_entity_reference": "^3.0 || ^4.0"
-            },
-            "require-dev": {
-                "drupal/redirect": "^1.8"
-            },
-            "type": "drupal-module",
-            "extra": {
-                "drupal": {
-                    "version": "2.0.0-alpha1",
-                    "datestamp": "1674444668",
-                    "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Alpha releases are not covered by Drupal security advisories."
-                    }
-                },
-                "drush": {
-                    "services": {
-                        "drush.services.yml": "^10 || ^11"
-                    }
-                }
-            },
-            "notification-url": "https://packages.drupal.org/8/downloads",
-            "license": [
-                "GPL-2.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "hass",
-                    "homepage": "https://www.drupal.org/u/hass"
-                },
-                {
-                    "name": "See other contributors",
-                    "homepage": "https://www.drupal.org/node/243795/committers"
-                },
-                {
-                    "name": "hass",
-                    "homepage": "https://www.drupal.org/user/85918"
-                },
-                {
-                    "name": "VladimirAus",
-                    "homepage": "https://www.drupal.org/user/673120"
-                }
-            ],
-            "description": "Periodically checks for broken links in node types, blocks and fields and reports the results.",
-            "homepage": "https://www.drupal.org/project/linkchecker",
-            "support": {
-                "source": "https://git.drupal.org/project/linkchecker.git",
-                "issues": "https://www.drupal.org/project/issues/linkchecker"
             }
         },
         {
@@ -18210,5 +18082,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -33,6 +33,8 @@ module:
   entity_browser_entity_form: 0
   entity_reference_revisions: 0
   entity_usage: 0
+  environment_indicator: 0
+  environment_indicator_ui: 0
   features: 0
   field: 0
   field_group: 0

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -22,6 +22,7 @@ module:
   crop: 0
   ctools: 0
   datetime: 0
+  dblog: 0
   decoupled_router: 0
   default_content: 0
   diff: 0

--- a/conf/cmi/environment_indicator.indicator.yml
+++ b/conf/cmi/environment_indicator.indicator.yml
@@ -1,0 +1,3 @@
+name: Local
+fg_color: '#000000'
+bg_color: '#000000'

--- a/conf/cmi/environment_indicator.settings.yml
+++ b/conf/cmi/environment_indicator.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: Bi0EyyiH6m5wpHRfxlKhqTIhAZayhRQudheDzAcrotU
+toolbar_integration:
+  toolbar: '0'
+favicon: true

--- a/conf/cmi/environment_indicator.switcher.development.yml
+++ b/conf/cmi/environment_indicator.switcher.development.yml
@@ -1,0 +1,11 @@
+uuid: 78d3f855-56ed-4d24-9ded-fec27c6278ab
+langcode: en
+status: true
+dependencies: {  }
+machine: development
+description: null
+name: Development
+weight: '4'
+url: 'https://edit-infofinland.dev.hel.ninja/'
+fg_color: '#d0d0d0'
+bg_color: '#33d17a'

--- a/conf/cmi/environment_indicator.switcher.development.yml
+++ b/conf/cmi/environment_indicator.switcher.development.yml
@@ -7,5 +7,5 @@ description: null
 name: Development
 weight: '4'
 url: 'https://edit-infofinland.dev.hel.ninja/'
-fg_color: '#d0d0d0'
+fg_color: '#000000'
 bg_color: '#33d17a'

--- a/conf/cmi/environment_indicator.switcher.production.yml
+++ b/conf/cmi/environment_indicator.switcher.production.yml
@@ -1,0 +1,11 @@
+uuid: f8586964-5d99-4c91-bf9a-970d94279169
+langcode: en
+status: true
+dependencies: {  }
+machine: production
+description: null
+name: Production
+weight: '1'
+url: 'https://edit.infofinland.fi/'
+fg_color: '#000000'
+bg_color: '#ffffff'

--- a/conf/cmi/environment_indicator.switcher.stage.yml
+++ b/conf/cmi/environment_indicator.switcher.stage.yml
@@ -1,0 +1,11 @@
+uuid: c2fe6566-96ed-474e-98ee-08dbc8b2c79d
+langcode: en
+status: true
+dependencies: {  }
+machine: stage
+description: null
+name: Stage
+weight: '2'
+url: 'https://infofinland-edit.stage.hel.ninja/'
+fg_color: '#d0d0d0'
+bg_color: '#3584e4'

--- a/conf/cmi/environment_indicator.switcher.stage.yml
+++ b/conf/cmi/environment_indicator.switcher.stage.yml
@@ -7,5 +7,5 @@ description: null
 name: Stage
 weight: '2'
 url: 'https://infofinland-edit.stage.hel.ninja/'
-fg_color: '#d0d0d0'
+fg_color: '#000000'
 bg_color: '#3584e4'

--- a/conf/cmi/environment_indicator.switcher.test.yml
+++ b/conf/cmi/environment_indicator.switcher.test.yml
@@ -7,5 +7,5 @@ description: null
 name: Test
 weight: '3'
 url: 'https://edit-infofinland.test.hel.ninja/'
-fg_color: '#d0d0d0'
+fg_color: '#000000'
 bg_color: '#ed333b'

--- a/conf/cmi/environment_indicator.switcher.test.yml
+++ b/conf/cmi/environment_indicator.switcher.test.yml
@@ -1,0 +1,11 @@
+uuid: 9103bd51-4148-42ca-a636-a485deef46dc
+langcode: en
+status: true
+dependencies: {  }
+machine: test
+description: null
+name: Test
+weight: '3'
+url: 'https://edit-infofinland.test.hel.ninja/'
+fg_color: '#d0d0d0'
+bg_color: '#ed333b'

--- a/conf/cmi/field.field.node.page.field_content.yml
+++ b/conf/cmi/field.field.node.page.field_content.yml
@@ -25,86 +25,92 @@ label: Pääsisältö
 description: ''
 required: false
 translatable: true
-skip_translation_check: null
+skip_translation_check: false
 default_value: {  }
 default_value_callback: ''
 settings:
   handler: 'default:paragraph'
   handler_settings:
     target_bundles:
-      text: text
       heading: heading
-      accordion: accordion
-      columns: columns
-      image: image
+      text: text
       language_link_collection: language_link_collection
-      ptv_contact: ptv_contact
+      accordion: accordion
+      image: image
       municipality_liftup: municipality_liftup
+      columns: columns
+      ptv_contact: ptv_contact
       remote_video: remote_video
       helsinki_kanava: helsinki_kanava
     negate: 0
     target_bundles_drag_drop:
       accordion:
-        weight: -41
+        weight: -44
         enabled: true
       accordion_item:
-        weight: -40
-        enabled: false
-      banner:
-        weight: -39
-        enabled: false
-      columns:
-        weight: -38
-        enabled: true
-      content_cards:
         weight: -37
         enabled: false
-      external_video:
-        weight: -30
-        enabled: false
-      gallery:
+      banner:
         weight: -36
         enabled: false
-      gallery_slide:
+      columns:
+        weight: -41
+        enabled: true
+      content_cards:
         weight: -35
         enabled: false
-      heading:
-        weight: -42
-        enabled: true
-      helsinki_kanava:
-        weight: -23
-        enabled: true
-      hero:
-        weight: -34
-        enabled: false
-      image:
-        weight: -33
-        enabled: true
-      language_link:
-        weight: -28
-        enabled: false
-      language_link_collection:
-        weight: -27
-        enabled: true
-      liftup_with_image:
-        weight: -32
-        enabled: false
-      list_of_links:
-        weight: -31
-        enabled: false
-      list_of_links_item:
+      external_video:
         weight: -29
         enabled: false
-      municipality_liftup:
-        weight: -25
+      gallery:
+        weight: -34
+        enabled: false
+      gallery_slide:
+        weight: -33
+        enabled: false
+      heading:
+        weight: -47
         enabled: true
-      ptv_contact:
+      helsinki_kanava:
+        weight: -38
+        enabled: true
+      hero:
+        weight: -32
+        enabled: false
+      image:
+        weight: -43
+        enabled: true
+      language_link:
+        weight: -27
+        enabled: false
+      language_link_collection:
+        weight: -45
+        enabled: true
+      liftup_with_image:
+        weight: -31
+        enabled: false
+      list_of_links:
+        weight: -30
+        enabled: false
+      list_of_links_item:
+        weight: -28
+        enabled: false
+      municipality_info:
         weight: -26
+        enabled: false
+      municipality_liftup:
+        weight: -42
+        enabled: true
+      municipality_liftup_item:
+        weight: -25
+        enabled: false
+      ptv_contact:
+        weight: -40
         enabled: true
       remote_video:
-        weight: -24
+        weight: -39
         enabled: true
       text:
-        weight: -43
+        weight: -46
         enabled: true
 field_type: entity_reference_revisions

--- a/conf/cmi/language/fi/views.view.content.yml
+++ b/conf/cmi/language/fi/views.view.content.yml
@@ -7,7 +7,7 @@ display:
         type:
           label: Sisältötyyppi
         name:
-          label: Tekijä
+          label: Päivittänyt
         status:
           label: Tila
           settings:
@@ -17,6 +17,12 @@ display:
           label: Päivitetty
         operations:
           label: Toimenpiteet
+        langcode:
+          label: Kieli
+        moderation_state:
+          label: Julkaisutila
+        field_page_name:
+          label: Nimi
       title: Sisältö
       pager:
         options:
@@ -24,14 +30,11 @@ display:
             next: 'Seuraava ›'
             previous: '‹ Edellinen'
             first: '« Ensimmäinen'
-            last: 'Last »'
       exposed_form:
         options:
           submit_button: Suodatus
           reset_button_label: Palauta
           exposed_sorts_label: Lajittele
-          sort_asc_label: Asc
-          sort_desc_label: Desc
       empty:
         area_text_custom:
           content: 'Ei sisältöä.'

--- a/conf/cmi/node.type.article.yml
+++ b/conf/cmi/node.type.article.yml
@@ -24,8 +24,8 @@ third_party_settings:
     unpublish_required: false
     unpublish_revision: false
   node_revision_delete:
-    minimum_revisions_to_keep: 5
     minimum_age_to_delete: 0
+    minimum_revisions_to_keep: 5
     when_to_delete: 0
 _core:
   default_config_hash: 55S0TlpZeQGEnh_bhvpAW797f2LnTyORBp4AUhX2qwI

--- a/conf/cmi/node.type.landing_page.yml
+++ b/conf/cmi/node.type.landing_page.yml
@@ -25,8 +25,8 @@ third_party_settings:
     unpublish_required: false
     unpublish_revision: false
   node_revision_delete:
-    minimum_revisions_to_keep: 5
     minimum_age_to_delete: 0
+    minimum_revisions_to_keep: 5
     when_to_delete: 0
 _core:
   default_config_hash: ah3vIiRAXEYtaITIDXDkTMxz_d55Eu7rV-nNz1ZknEU

--- a/conf/cmi/node.type.link.yml
+++ b/conf/cmi/node.type.link.yml
@@ -24,8 +24,8 @@ third_party_settings:
     unpublish_required: false
     unpublish_revision: false
   node_revision_delete:
-    minimum_revisions_to_keep: 5
     minimum_age_to_delete: 0
+    minimum_revisions_to_keep: 5
     when_to_delete: 0
 name: Linkki
 type: link

--- a/conf/cmi/node.type.message.yml
+++ b/conf/cmi/node.type.message.yml
@@ -24,8 +24,8 @@ third_party_settings:
     unpublish_required: false
     unpublish_revision: false
   node_revision_delete:
-    minimum_revisions_to_keep: 5
     minimum_age_to_delete: 0
+    minimum_revisions_to_keep: 5
     when_to_delete: 0
 name: Message
 type: message

--- a/conf/cmi/node.type.office_contact_info.yml
+++ b/conf/cmi/node.type.office_contact_info.yml
@@ -24,8 +24,8 @@ third_party_settings:
     unpublish_required: false
     unpublish_revision: false
   node_revision_delete:
-    minimum_revisions_to_keep: 5
     minimum_age_to_delete: 0
+    minimum_revisions_to_keep: 5
     when_to_delete: 0
 name: 'Toimipaikan yhteystiedot'
 type: office_contact_info

--- a/conf/cmi/node.type.page.yml
+++ b/conf/cmi/node.type.page.yml
@@ -25,8 +25,8 @@ third_party_settings:
     unpublish_required: false
     unpublish_revision: false
   node_revision_delete:
-    minimum_revisions_to_keep: 5
     minimum_age_to_delete: 0
+    minimum_revisions_to_keep: 5
     when_to_delete: 0
 _core:
   default_config_hash: 2wtLJzGRPIAAdAGbl6hOGq0wG3zumh1dayzTQvnwU94

--- a/conf/cmi/simple_oauth.settings.yml
+++ b/conf/cmi/simple_oauth.settings.yml
@@ -4,8 +4,8 @@ access_token_expiration: 300
 authorization_code_expiration: 300
 refresh_token_expiration: 1209600
 token_cron_batch_size: 0
-public_key: /app/keys/public.key
-private_key: /app/keys/private.key
+public_key: /var/www/html/keys/public.key
+private_key: /var/www/html/keys/private.key
 remember_clients: true
 use_implicit: false
 disable_openid_connect: false

--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -3,9 +3,14 @@ langcode: en
 status: true
 dependencies:
   config:
+    - environment_indicator.switcher.development
+    - environment_indicator.switcher.production
+    - environment_indicator.switcher.stage
+    - environment_indicator.switcher.test
     - filter.format.full_html
     - filter.format.simple_html
   module:
+    - environment_indicator
     - filter
     - legal
     - media
@@ -19,6 +24,11 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
+  - 'access environment indicator'
+  - 'access environment indicator development'
+  - 'access environment indicator production'
+  - 'access environment indicator stage'
+  - 'access environment indicator test'
   - 'use text format full_html'
   - 'use text format simple_html'
   - 'view Terms and Conditions'

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -851,15 +851,15 @@ display:
           exposed: true
           expose:
             operator_id: langcode_op
-            label: Language
+            label: 'Translation language'
             description: ''
-            use_operator: true
+            use_operator: false
             operator: langcode_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: langcode
             required: false
-            remember: true
+            remember: false
             multiple: false
             remember_roles:
               authenticated: authenticated
@@ -870,7 +870,7 @@ display:
               municipal_editor: '0'
               nextjs: '0'
               infofinland_admin: '0'
-            reduce: true
+            reduce: false
           is_grouped: false
           group_info:
             label: ''

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -853,13 +853,13 @@ display:
             operator_id: langcode_op
             label: Language
             description: ''
-            use_operator: false
+            use_operator: true
             operator: langcode_op
             operator_limit_selection: false
             operator_list: {  }
             identifier: langcode
             required: false
-            remember: false
+            remember: true
             multiple: false
             remember_roles:
               authenticated: authenticated
@@ -1070,7 +1070,11 @@ display:
           plugin_id: standard
           required: false
       show_admin_links: false
-      display_extenders: {  }
+      rendering_language: '***LANGUAGE_entity_translation***'
+      display_extenders:
+        metatag_display_extender:
+          metatags: {  }
+          tokenize: false
     cache_metadata:
       max-age: 0
       contexts:
@@ -1089,7 +1093,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
-      rendering_language: '***LANGUAGE_entity_default***'
+      rendering_language: '***LANGUAGE_entity_translation***'
       display_extenders:
         metatag_display_extender:
           metatags: {  }
@@ -1111,6 +1115,7 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
+        - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -847,7 +847,6 @@ display:
             zh: zh
             fa: fa
             ar: ar
-            so: so
           group: 1
           exposed: true
           expose:
@@ -870,6 +869,7 @@ display:
               content_producer: '0'
               municipal_editor: '0'
               nextjs: '0'
+              infofinland_admin: '0'
             reduce: true
           is_grouped: false
           group_info:
@@ -1089,6 +1089,7 @@ display:
     display_plugin: page
     position: 1
     display_options:
+      rendering_language: '***LANGUAGE_entity_default***'
       display_extenders:
         metatag_display_extender:
           metatags: {  }
@@ -1110,7 +1111,6 @@ display:
     cache_metadata:
       max-age: 0
       contexts:
-        - 'languages:language_content'
         - 'languages:language_interface'
         - url
         - url.query_args

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -238,21 +238,67 @@ display:
           id: name
           table: users_field_data
           field: name
-          relationship: uid
+          relationship: revision_uid
+          group_type: group
+          admin_label: ''
           entity_type: user
           entity_field: name
           plugin_id: field
-          label: Author
+          label: 'Last updated by'
           exclude: false
           alter:
             alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
           element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
           element_default_classes: true
           empty: ''
           hide_empty: false
           empty_zero: false
           hide_alter_empty: true
+          click_sort_column: value
           type: user_name
+          settings:
+            link_to_entity: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
         langcode:
           id: langcode
           table: node_field_data
@@ -1012,13 +1058,17 @@ display:
       query:
         type: views_query
       relationships:
-        uid:
-          id: uid
-          table: node_field_data
-          field: uid
-          admin_label: author
+        revision_uid:
+          id: revision_uid
+          table: node_revision
+          field: revision_uid
+          relationship: none
+          group_type: group
+          admin_label: 'revision user'
+          entity_type: node
+          entity_field: revision_uid
           plugin_id: standard
-          required: true
+          required: false
       show_admin_links: false
       display_extenders: {  }
     cache_metadata:

--- a/conf/cmi/views.view.content.yml
+++ b/conf/cmi/views.view.content.yml
@@ -114,7 +114,7 @@ display:
           group_type: group
           admin_label: ''
           plugin_id: field
-          label: Nimi
+          label: Name
           exclude: false
           alter:
             alter_text: false

--- a/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
+++ b/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
@@ -38,7 +38,7 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
    *
    * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $entityManager;
+  protected $entityTypeManager;
 
   /**
    * The logger.

--- a/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
+++ b/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
@@ -132,7 +132,7 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
    * @return int
    */
   private function checkUrlStatus(string $url): int {
-    $response = $this->httpClient->head($url, [
+    $response = $this->httpClient->get($url, [
       'http_errors' => FALSE,
       'allow_redirects' => [
         'max'             => 3,

--- a/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
+++ b/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
@@ -102,11 +102,28 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
       $code = $this->checkUrlStatus($response->field_language_link_value);
     } catch (\Exception $e) {
       $logger_params['@message'] = $e->getMessage();
-      $this->logger->warning('Checking URL failed: id: @id , parent_id: @parent_id, url: @url - @message ', $logger_params);
+      // This happens for example following reasons, 
+      // cURL error 28: Operation timed out after 30001 milliseconds with 0 bytes received (see https://curl.haxx.se/libcurl/c/libcurl-errors.html) 
+      // If this happens, the broken link status gets an empty value.
+      $this->logger->warning('Checking cURL status failed: parent_id: @parent_id , id: @id ,  url: @url - @message ', $logger_params);
       return;
     }
 
-    if ($code === 200) {
+    if ($code === 200 || $code === 301 || $code === 302 || $code === 303) {
+      if ($linkNode = $this->entityTypeManager->getStorage('node')->load($response->parent_id)) {
+        $linkNode->set('field_broken_link', false);
+        $linkNode->save();
+      }
+
+      if ($languageLinkParagraph = $this->entityTypeManager->getStorage('paragraph')->load($response->id)) {
+        $languageLinkParagraph->set('field_broken_link', false);
+        $languageLinkParagraph->save();
+      }
+
+      // $logger_params['@code'] = $code;
+      // $this->logger->warning('Checking URL status passed: parent_id: @parent_id , id: @id , url: @url - code: @code ', $logger_params);
+    }
+    else {
       if ($linkNode = $this->entityTypeManager->getStorage('node')->load($response->parent_id)) {
         $linkNode->set('field_broken_link', true);
         $linkNode->save();
@@ -115,11 +132,10 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
       if ($languageLinkParagraph = $this->entityTypeManager->getStorage('paragraph')->load($response->id)) {
         $languageLinkParagraph->set('field_broken_link', true);
         $languageLinkParagraph->save();
-      }
-    }
-    else {
+      }  
+
       $logger_params['@code'] = $code;
-      $this->logger->warning('Checking URL status failed: id: @id , parent_id: @parent_id, url: @url - code: @code ', $logger_params);
+      $this->logger->warning('Checking URL status failed: parent_id: @parent_id , id: @id , url: @url - code: @code ', $logger_params);
     }
   }
 

--- a/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
+++ b/public/modules/custom/infofinland_brokenlink_checker/src/Plugin/QueueWorker/BrokenLinkQueueProcessor.php
@@ -106,7 +106,7 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
       return;
     }
 
-    if ($code == 200) {
+    if ($code === 200) {
       if ($linkNode = $this->entityTypeManager->getStorage('node')->load($response->parent_id)) {
         $linkNode->set('field_broken_link', true);
         $linkNode->save();
@@ -129,9 +129,9 @@ class BrokenLinkQueueProcessor extends QueueWorkerBase implements ContainerFacto
    * @param string $url
    *   The url.
    *
-   * @return bool
+   * @return int
    */
-  private function checkUrlStatus(string $url): bool {
+  private function checkUrlStatus(string $url): int {
     $response = $this->httpClient->head($url, [
       'http_errors' => FALSE,
       'allow_redirects' => [

--- a/public/modules/custom/infofinland_gdpr/src/EventSubscriber/InfofinlandGdprSubscriber.php
+++ b/public/modules/custom/infofinland_gdpr/src/EventSubscriber/InfofinlandGdprSubscriber.php
@@ -11,15 +11,20 @@ use Drupal\user\Entity\User;
  * Class for logging when sensitive user information is being viewed or edited.
  */
 class InfofinlandGdprSubscriber implements EventSubscriberInterface {
-
   public function checkForUserPage(RequestEvent $event) {
+    // Todo This could be simplified, lots of duplicate code here.
     if ($event->getRequest()->get('_route') == 'entity.user.canonical') {
       $uid = $event->getRequest()->get('user')->uid->value;
       $account = User::load($uid);
       $name = $account->getAccountName();
 
+      // Optionally, log the message to a separate file.
+      $logFilePath = 'sites/default/files/logs/infofinland_gdpr.log';
+      $formattedMessage = date('Y-m-d H:i:s') . ' [notice] ' . 'user ' . $name . " view page visited.\n";
+      file_put_contents($logFilePath, $formattedMessage, FILE_APPEND);
+
       // Logs a notice when users page is visited.
-      \Drupal::logger('infofinland_gdpr')->notice('user %name visited.', ['%name' => $name]);
+      \Drupal::logger('infofinland_gdpr')->notice('user %name view page visited.', ['%name' => $name]);
     }
 
     if ($event->getRequest()->get('_route') == 'entity.user.edit_form') {
@@ -27,13 +32,24 @@ class InfofinlandGdprSubscriber implements EventSubscriberInterface {
       $account = User::load($uid);
       $name = $account->getAccountName();
 
+      // Optionally, log the message to a separate file.
+      $logFilePath = 'sites/default/files/logs/infofinland_gdpr.log';
+      $formattedMessage = date('Y-m-d H:i:s') . ' [notice] ' . 'user ' . $name . " edit page visited.\n";
+      file_put_contents($logFilePath, $formattedMessage, FILE_APPEND);
+
       // Logs a notice when users edit page is visited.
-      \Drupal::logger('infofinland_gdpr')->notice('user %name edit visited.', ['%name' => $name]);
+      \Drupal::logger('infofinland_gdpr')->notice('user %name edit page visited.', ['%name' => $name]);
     }
 
     if ($event->getRequest()->get('_route') == 'entity.user.collection') {
-      // Logs a notice when users admin page is visited.
-      \Drupal::logger('infofinland_gdpr')->notice('Users admin page visited');
+
+      // Optionally, log the message to a separate file.
+      $logFilePath = 'sites/default/files/logs/infofinland_gdpr.log';
+      $formattedMessage = date('Y-m-d H:i:s') . ' [notice] ' . "admin list page of users visited.\n";
+      file_put_contents($logFilePath, $formattedMessage, FILE_APPEND);
+
+      // Logs a notice when user list admin page is visited.
+      \Drupal::logger('infofinland_gdpr')->notice('admin list page of users visited.');
     }
   }
 
@@ -45,5 +61,6 @@ class InfofinlandGdprSubscriber implements EventSubscriberInterface {
 
     return $events;
   }
+
 
 }

--- a/public/sites/default/env.indicator.settings.php
+++ b/public/sites/default/env.indicator.settings.php
@@ -1,0 +1,27 @@
+<?php 
+/**
+ * The UI for environment indicator is broken, so we have to do this instead.
+ * See more info, https://www.drupal.org/project/environment_indicator/issues/2224983
+ */
+switch ($_SERVER['HTTP_HOST']) {
+	case 'edit.infofinland.fi/':
+		$config['environment_indicator.indicator']['bg_color'] = '#ffffff';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Production';
+		$break;
+	case 'infofinland-edit.stage.hel.ninja':
+		$config['environment_indicator.indicator']['bg_color'] = '#3584e4';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Stage';
+		$break;
+	case 'edit-infofinland.test.hel.ninja':
+		$config['environment_indicator.indicator']['bg_color'] = '#ed333b';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Test';
+		$break;
+	case 'edit-infofinland.dev.hel.ninja':
+		$config['environment_indicator.indicator']['bg_color'] = '#33d17a';
+		$config['environment_indicator.indicator']['fg_color'] = '#000000';
+		$config['environment_indicator.indicator']['name'] = 'Development';
+		break;
+}

--- a/public/sites/default/env.indicator.settings.php
+++ b/public/sites/default/env.indicator.settings.php
@@ -4,21 +4,21 @@
  * See more info, https://www.drupal.org/project/environment_indicator/issues/2224983
  */
 switch ($_SERVER['HTTP_HOST']) {
-	case 'edit.infofinland.fi/':
+	case 'edit.infofinland.fi':
 		$config['environment_indicator.indicator']['bg_color'] = '#ffffff';
 		$config['environment_indicator.indicator']['fg_color'] = '#000000';
 		$config['environment_indicator.indicator']['name'] = 'Production';
-		$break;
+		break;
 	case 'infofinland-edit.stage.hel.ninja':
 		$config['environment_indicator.indicator']['bg_color'] = '#3584e4';
 		$config['environment_indicator.indicator']['fg_color'] = '#000000';
 		$config['environment_indicator.indicator']['name'] = 'Stage';
-		$break;
+		break;
 	case 'edit-infofinland.test.hel.ninja':
 		$config['environment_indicator.indicator']['bg_color'] = '#ed333b';
 		$config['environment_indicator.indicator']['fg_color'] = '#000000';
 		$config['environment_indicator.indicator']['name'] = 'Test';
-		$break;
+		break;
 	case 'edit-infofinland.dev.hel.ninja':
 		$config['environment_indicator.indicator']['bg_color'] = '#33d17a';
 		$config['environment_indicator.indicator']['fg_color'] = '#000000';

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -231,3 +231,9 @@ if ($env = getenv('APP_ENV')) {
 //if (file_exists(__DIR__ . '/' . 'local' . '.settings.php')) {
 //  include __DIR__ . '/' . 'local' . '.settings.php';
 //}
+
+// Automatically generated include for settings managed by ddev.
+$ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
+if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
+  require $ddev_settings;
+}

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -237,3 +237,9 @@ $ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
 if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
   require_once $ddev_settings; // TODO Check this if something stops working, `require`.
 }
+
+// Environment indicator hack, see the file for more info
+$env_indicator_settings = dirname(__FILE__) . '/env.indicator.settings.php';
+if (file_exists($env_indicator_settings)) {
+  require_once $env_indicator_settings;
+}

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -204,9 +204,9 @@ if (
 }
 
 if (getenv('INFOFINLAND_UI_URL')) {
-  $settings['next.next_site']['infofinland_ui']['base_url'] = getenv('INFOFINLAND_UI_URL');
-  $settings['next.next_site']['infofinland_ui']['preview_url'] = getenv('INFOFINLAND_UI_PREVIEW_URL');
-  $settings['next.next_site']['infofinland_ui']['preview_secret'] = getenv('DRUPAL_PREVIEW_SECRET');
+  $config['next.next_site.infofinland_ui']['base_url'] = getenv('INFOFINLAND_UI_URL');
+  $config['next.next_site.infofinland_ui']['preview_url'] = getenv('INFOFINLAND_UI_PREVIEW_URL');
+  $config['next.next_site.infofinland_ui']['preview_secret'] = getenv('DRUPAL_PREVIEW_SECRET');
 }
 
 // Environment specific overrides.

--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -235,5 +235,5 @@ if ($env = getenv('APP_ENV')) {
 // Automatically generated include for settings managed by ddev.
 $ddev_settings = dirname(__FILE__) . '/settings.ddev.php';
 if (getenv('IS_DDEV_PROJECT') == 'true' && is_readable($ddev_settings)) {
-  require $ddev_settings;
+  require_once $ddev_settings; // TODO Check this if something stops working, `require`.
 }


### PR DESCRIPTION
This should make it possible to get logs for people with permissions to view from /admin/reports/dblog when any of these pages has been accessed:
- user page
- user edit page
- user listing

It is also saved in public/sites/default/files/logs/infofinland_gdpr.log 