### PR TITLE
IFU-817: Real-time SEO

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
         "drupal/ultimate_cron": "^2.0@alpha",
         "drupal/varnish_purge": "^2.1",
         "drupal/webform_rest": "^4.0",
+        "drupal/yoast_seo": "^2.0@alpha",
         "drush/drush": "^10.4"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "913d630cbab73a8a1da4ee2ce91fad1a",
+    "content-hash": "35d6cba12d9def57b6443c6ab6cb3ccf",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -7869,6 +7869,88 @@
             }
         },
         {
+            "name": "drupal/yoast_seo",
+            "version": "2.0.0-alpha9",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/yoast_seo.git",
+                "reference": "8.x-2.0-alpha9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/yoast_seo-8.x-2.0-alpha9.zip",
+                "reference": "8.x-2.0-alpha9",
+                "shasum": "1fd2695b289a1e725a293e378c0066c18e8c8407"
+            },
+            "require": {
+                "drupal/core": "^8 || ^9 || ^10",
+                "drupal/metatag": "^1.3",
+                "goalgorilla/rtseo.js": "^2.0"
+            },
+            "conflict": {
+                "drupal/commerce": ">2.0 <2.5"
+            },
+            "require-dev": {
+                "composer/installers": "^2",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",
+                "dmore/behat-chrome-extension": "^1.4",
+                "drupal/devel": "^5.0.2",
+                "drupal/drupal-extension": "^5",
+                "drupal/paragraphs": "^1.15",
+                "drush/drush": "^11.0",
+                "friends-of-behat/mink-debug-extension": "^2.1",
+                "mglaman/phpstan-drupal": "^1.1.25",
+                "phpspec/prophecy-phpunit": "v2.0.1",
+                "phpstan/extension-installer": "^1.1.0",
+                "phpstan/phpstan": "^1.9.2",
+                "phpstan/phpstan-deprecation-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.1.1"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.0-alpha9",
+                    "datestamp": "1686928294",
+                    "security-coverage": {
+                        "status": "not-covered",
+                        "message": "Alpha releases are not covered by Drupal security advisories."
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "bramtenhove",
+                    "homepage": "https://www.drupal.org/user/1549848"
+                },
+                {
+                    "name": "Kingdutch",
+                    "homepage": "https://www.drupal.org/user/1868952"
+                },
+                {
+                    "name": "Open Social",
+                    "homepage": "https://www.drupal.org/user/272162"
+                },
+                {
+                    "name": "robertragas",
+                    "homepage": "https://www.drupal.org/user/2723261"
+                },
+                {
+                    "name": "ronaldtebrake",
+                    "homepage": "https://www.drupal.org/user/2314038"
+                }
+            ],
+            "description": "Adds Real-time SEO page analysis and configuration.",
+            "homepage": "http://drupal.org/project/yoast_seo",
+            "support": {
+                "source": "http://cgit.drupalcode.org/yoast_seo",
+                "issues": "http://drupal.org/project/yoast_seo"
+            }
+        },
+        {
             "name": "drush/drush",
             "version": "10.6.2",
             "source": {
@@ -8467,6 +8549,32 @@
                 "source": "https://github.com/Galbar/JsonPath-PHP/tree/1.3.1"
             },
             "time": "2021-08-19T20:18:48+00:00"
+        },
+        {
+            "name": "goalgorilla/rtseo.js",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/goalgorilla/RTSEO.js.git",
+                "reference": "ab5f9c3ff478e0e9d61f5cc3831038e4f22bbbb0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/goalgorilla/RTSEO.js/zipball/ab5f9c3ff478e0e9d61f5cc3831038e4f22bbbb0",
+                "reference": "ab5f9c3ff478e0e9d61f5cc3831038e4f22bbbb0",
+                "shasum": ""
+            },
+            "type": "drupal-library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "GPL-3.0"
+            ],
+            "description": "Text analysis application for use with the Real-Time SEO Drupal module.",
+            "homepage": "https://github.com/goalgorilla/RTSEO.js",
+            "support": {
+                "source": "https://github.com/goalgorilla/RTSEO.js/tree/2.1.0"
+            },
+            "time": "2018-01-19T23:11:36+00:00"
         },
         {
             "name": "grasmash/expander",
@@ -18076,11 +18184,12 @@
         "drupal/helfi_drupal_tools": 20,
         "drupal/inline_entity_form": 5,
         "drupal/node_revision_delete": 15,
-        "drupal/ultimate_cron": 15
+        "drupal/ultimate_cron": 15,
+        "drupal/yoast_seo": 15
     },
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/conf/cmi/core.entity_form_display.node.article.default.yml
+++ b/conf/cmi/core.entity_form_display.node.article.default.yml
@@ -8,7 +8,9 @@ dependencies:
     - field.field.node.article.field_keywords
     - field.field.node.article.field_lead
     - field.field.node.article.field_liftup_image
+    - field.field.node.article.field_meta_tags
     - field.field.node.article.field_metatags
+    - field.field.node.article.field_yoast_seo
     - node.type.article
   module:
     - hdbt_admin_editorial
@@ -18,6 +20,7 @@ dependencies:
     - path
     - scheduler
     - select2
+    - yoast_seo
 _core:
   default_config_hash: pCNOhgqtZB0RYWLFELZhHp654GnKfoQ_Dbd2v2MIrWU
 id: node.article.default
@@ -90,6 +93,16 @@ content:
     settings:
       sidebar: false
       use_details: true
+    third_party_settings: {  }
+  field_yoast_seo:
+    type: yoast_seo_widget
+    weight: 19
+    region: content
+    settings:
+      edit_title: '1'
+      edit_description: '1'
+      render_theme: claro
+      render_view_mode: default
     third_party_settings: {  }
   langcode:
     type: language_select
@@ -171,4 +184,6 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
+  hide_sidebar_navigation: true
   moderation_state: true

--- a/conf/cmi/core.entity_form_display.node.landing_page.default.yml
+++ b/conf/cmi/core.entity_form_display.node.landing_page.default.yml
@@ -8,9 +8,11 @@ dependencies:
     - field.field.node.landing_page.field_feedback_email
     - field.field.node.landing_page.field_hero
     - field.field.node.landing_page.field_liftup_image
+    - field.field.node.landing_page.field_meta_tags
     - field.field.node.landing_page.field_metatags
     - field.field.node.landing_page.field_page_name
     - field.field.node.landing_page.field_url
+    - field.field.node.landing_page.field_yoast_seo
     - node.type.landing_page
   module:
     - content_moderation
@@ -20,6 +22,7 @@ dependencies:
     - paragraphs
     - path
     - scheduler
+    - yoast_seo
 _core:
   default_config_hash: WWqDZY1evGw93ACn6U7IeBc6IVYvWvPow-lKIQEA0mY
 id: node.landing_page.default
@@ -117,6 +120,16 @@ content:
       size: 60
       placeholder: ''
     third_party_settings: {  }
+  field_yoast_seo:
+    type: yoast_seo_widget
+    weight: 22
+    region: content
+    settings:
+      edit_title: '1'
+      edit_description: '1'
+      render_theme: claro
+      render_view_mode: default
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0
@@ -202,4 +215,6 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-hidden: {  }
+hidden:
+  field_meta_tags: true
+  hide_sidebar_navigation: true

--- a/conf/cmi/core.entity_form_display.node.link.default.yml
+++ b/conf/cmi/core.entity_form_display.node.link.default.yml
@@ -7,7 +7,9 @@ dependencies:
     - field.field.node.link.field_link_description
     - field.field.node.link.field_link_target_site
     - field.field.node.link.field_links
+    - field.field.node.link.field_meta_tags
     - field.field.node.link.field_municipality
+    - field.field.node.link.field_yoast_seo
     - node.type.link
   module:
     - hdbt_admin_editorial
@@ -153,5 +155,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
+  field_yoast_seo: true
   hide_sidebar_navigation: true
   moderation_state: true

--- a/conf/cmi/core.entity_form_display.node.message.default.yml
+++ b/conf/cmi/core.entity_form_display.node.message.default.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - field.field.node.message.body
     - field.field.node.message.field_message_type
+    - field.field.node.message.field_meta_tags
     - field.field.node.message.field_page
+    - field.field.node.message.field_yoast_seo
     - node.type.message
   module:
     - hdbt_admin_editorial
@@ -112,6 +114,9 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_meta_tags: true
+  field_yoast_seo: true
+  hide_sidebar_navigation: true
   moderation_state: true
   path: true
   url_redirects: true

--- a/conf/cmi/core.entity_form_display.node.office_contact_info.default.yml
+++ b/conf/cmi/core.entity_form_display.node.office_contact_info.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.office_contact_info.field_automated_updates
     - field.field.node.office_contact_info.field_email_address
+    - field.field.node.office_contact_info.field_meta_tags
     - field.field.node.office_contact_info.field_new_data
     - field.field.node.office_contact_info.field_office_id
     - field.field.node.office_contact_info.field_phonenumber
@@ -13,6 +14,7 @@ dependencies:
     - field.field.node.office_contact_info.field_service_hours
     - field.field.node.office_contact_info.field_visiting_address
     - field.field.node.office_contact_info.field_visiting_address_additiona
+    - field.field.node.office_contact_info.field_yoast_seo
     - node.type.office_contact_info
   module:
     - hdbt_admin_editorial
@@ -114,7 +116,10 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_meta_tags: true
   field_office_id: true
+  field_yoast_seo: true
+  hide_sidebar_navigation: true
   moderation_state: true
   path: true
   promote: true

--- a/conf/cmi/core.entity_form_display.node.page.default.yml
+++ b/conf/cmi/core.entity_form_display.node.page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.page.field_hero
     - field.field.node.page.field_layout
     - field.field.node.page.field_liftup_image
+    - field.field.node.page.field_meta_tags
     - field.field.node.page.field_metatags
     - field.field.node.page.field_municipality_info
     - field.field.node.page.field_municipality_selection
@@ -18,6 +19,7 @@ dependencies:
     - field.field.node.page.field_theme_menu_machine_name
     - field.field.node.page.field_url
     - field.field.node.page.field_use_anchor_links
+    - field.field.node.page.field_yoast_seo
     - node.type.page
     - workflows.workflow.editorial
   module:
@@ -30,6 +32,7 @@ dependencies:
     - path
     - scheduler
     - select2
+    - yoast_seo
 third_party_settings:
   field_group:
     group_kuntainfo_sivupalkissa:
@@ -199,6 +202,16 @@ content:
     settings:
       display_label: true
     third_party_settings: {  }
+  field_yoast_seo:
+    type: yoast_seo_widget
+    weight: 23
+    region: content
+    settings:
+      edit_title: '1'
+      edit_description: '1'
+      render_theme: stark
+      render_view_mode: default
+    third_party_settings: {  }
   langcode:
     type: language_select
     weight: 0
@@ -287,4 +300,6 @@ content:
 hidden:
   field_finnish_title: true
   field_liftup_image: true
+  field_meta_tags: true
   field_theme_menu_machine_name: true
+  hide_sidebar_navigation: true

--- a/conf/cmi/core.entity_view_display.node.article.default.yml
+++ b/conf/cmi/core.entity_view_display.node.article.default.yml
@@ -8,12 +8,15 @@ dependencies:
     - field.field.node.article.field_keywords
     - field.field.node.article.field_lead
     - field.field.node.article.field_liftup_image
+    - field.field.node.article.field_meta_tags
     - field.field.node.article.field_metatags
+    - field.field.node.article.field_yoast_seo
     - node.type.article
   module:
     - entity_reference_revisions
     - metatag
     - user
+    - yoast_seo
 _core:
   default_config_hash: iP63ruNj8P30AR0u-V9j_M03qHUEpzx-qneyWJtGvNw
 id: node.article.default
@@ -60,6 +63,13 @@ content:
     third_party_settings: {  }
     weight: 5
     region: content
+  field_yoast_seo:
+    type: yoastseo_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 6
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -67,4 +77,6 @@ content:
     region: content
 hidden:
   field_liftup_image: true
+  field_meta_tags: true
   langcode: true
+  search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.article.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.article.teaser.yml
@@ -9,7 +9,9 @@ dependencies:
     - field.field.node.article.field_keywords
     - field.field.node.article.field_lead
     - field.field.node.article.field_liftup_image
+    - field.field.node.article.field_meta_tags
     - field.field.node.article.field_metatags
+    - field.field.node.article.field_yoast_seo
     - node.type.article
   module:
     - user
@@ -34,6 +36,9 @@ hidden:
   field_content: true
   field_keywords: true
   field_lead: true
+  field_meta_tags: true
   field_metatags: true
+  field_yoast_seo: true
   langcode: true
   links: true
+  search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.landing_page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.landing_page.default.yml
@@ -8,12 +8,16 @@ dependencies:
     - field.field.node.landing_page.field_feedback_email
     - field.field.node.landing_page.field_hero
     - field.field.node.landing_page.field_liftup_image
+    - field.field.node.landing_page.field_meta_tags
     - field.field.node.landing_page.field_metatags
     - field.field.node.landing_page.field_page_name
     - field.field.node.landing_page.field_url
+    - field.field.node.landing_page.field_yoast_seo
     - node.type.landing_page
   module:
+    - metatag
     - user
+    - yoast_seo
 _core:
   default_config_hash: LuhyhnsQ44RvvqWLYbkgiR7_IFywxuxn3pPaBDaYIgc
 id: node.landing_page.default
@@ -21,6 +25,20 @@ targetEntityType: node
 bundle: landing_page
 mode: default
 content:
+  field_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 1
+    region: content
+  field_yoast_seo:
+    type: yoastseo_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
   links:
     settings: {  }
     third_party_settings: {  }
@@ -32,7 +50,7 @@ hidden:
   field_feedback_email: true
   field_hero: true
   field_liftup_image: true
-  field_metatags: true
+  field_meta_tags: true
   field_page_name: true
   field_url: true
   langcode: true

--- a/conf/cmi/core.entity_view_display.node.landing_page.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.landing_page.teaser.yml
@@ -9,9 +9,11 @@ dependencies:
     - field.field.node.landing_page.field_feedback_email
     - field.field.node.landing_page.field_hero
     - field.field.node.landing_page.field_liftup_image
+    - field.field.node.landing_page.field_meta_tags
     - field.field.node.landing_page.field_metatags
     - field.field.node.landing_page.field_page_name
     - field.field.node.landing_page.field_url
+    - field.field.node.landing_page.field_yoast_seo
     - node.type.landing_page
   module:
     - user
@@ -36,9 +38,11 @@ hidden:
   field_description: true
   field_feedback_email: true
   field_hero: true
+  field_meta_tags: true
   field_metatags: true
   field_page_name: true
   field_url: true
+  field_yoast_seo: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.link.default.yml
+++ b/conf/cmi/core.entity_view_display.node.link.default.yml
@@ -7,7 +7,9 @@ dependencies:
     - field.field.node.link.field_link_description
     - field.field.node.link.field_link_target_site
     - field.field.node.link.field_links
+    - field.field.node.link.field_meta_tags
     - field.field.node.link.field_municipality
+    - field.field.node.link.field_yoast_seo
     - node.type.link
   module:
     - entity_reference_revisions
@@ -49,6 +51,8 @@ content:
     region: content
 hidden:
   field_broken_link: true
+  field_meta_tags: true
   field_municipality: true
+  field_yoast_seo: true
   langcode: true
   search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.link.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.link.teaser.yml
@@ -8,7 +8,9 @@ dependencies:
     - field.field.node.link.field_link_description
     - field.field.node.link.field_link_target_site
     - field.field.node.link.field_links
+    - field.field.node.link.field_meta_tags
     - field.field.node.link.field_municipality
+    - field.field.node.link.field_yoast_seo
     - node.type.link
   module:
     - user
@@ -27,6 +29,8 @@ hidden:
   field_link_description: true
   field_link_target_site: true
   field_links: true
+  field_meta_tags: true
   field_municipality: true
+  field_yoast_seo: true
   langcode: true
   search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.message.default.yml
+++ b/conf/cmi/core.entity_view_display.node.message.default.yml
@@ -5,7 +5,9 @@ dependencies:
   config:
     - field.field.node.message.body
     - field.field.node.message.field_message_type
+    - field.field.node.message.field_meta_tags
     - field.field.node.message.field_page
+    - field.field.node.message.field_yoast_seo
     - node.type.message
   module:
     - user
@@ -22,5 +24,8 @@ content:
 hidden:
   body: true
   field_message_type: true
+  field_meta_tags: true
   field_page: true
+  field_yoast_seo: true
   langcode: true
+  search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.message.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.message.teaser.yml
@@ -6,7 +6,9 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.message.body
     - field.field.node.message.field_message_type
+    - field.field.node.message.field_meta_tags
     - field.field.node.message.field_page
+    - field.field.node.message.field_yoast_seo
     - node.type.message
   module:
     - text
@@ -31,5 +33,8 @@ content:
     region: content
 hidden:
   field_message_type: true
+  field_meta_tags: true
   field_page: true
+  field_yoast_seo: true
   langcode: true
+  search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.office_contact_info.default.yml
+++ b/conf/cmi/core.entity_view_display.node.office_contact_info.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.office_contact_info.field_automated_updates
     - field.field.node.office_contact_info.field_email_address
+    - field.field.node.office_contact_info.field_meta_tags
     - field.field.node.office_contact_info.field_new_data
     - field.field.node.office_contact_info.field_office_id
     - field.field.node.office_contact_info.field_phonenumber
@@ -13,6 +14,7 @@ dependencies:
     - field.field.node.office_contact_info.field_service_hours
     - field.field.node.office_contact_info.field_visiting_address
     - field.field.node.office_contact_info.field_visiting_address_additiona
+    - field.field.node.office_contact_info.field_yoast_seo
     - node.type.office_contact_info
   module:
     - user
@@ -112,4 +114,7 @@ content:
     third_party_settings: {  }
     weight: 9
     region: content
-hidden: {  }
+hidden:
+  field_meta_tags: true
+  field_yoast_seo: true
+  search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.office_contact_info.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.office_contact_info.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.office_contact_info.field_automated_updates
     - field.field.node.office_contact_info.field_email_address
+    - field.field.node.office_contact_info.field_meta_tags
     - field.field.node.office_contact_info.field_new_data
     - field.field.node.office_contact_info.field_office_id
     - field.field.node.office_contact_info.field_phonenumber
@@ -14,6 +15,7 @@ dependencies:
     - field.field.node.office_contact_info.field_service_hours
     - field.field.node.office_contact_info.field_visiting_address
     - field.field.node.office_contact_info.field_visiting_address_additiona
+    - field.field.node.office_contact_info.field_yoast_seo
     - node.type.office_contact_info
   module:
     - user
@@ -30,6 +32,7 @@ content:
 hidden:
   field_automated_updates: true
   field_email_address: true
+  field_meta_tags: true
   field_new_data: true
   field_office_id: true
   field_phonenumber: true
@@ -38,4 +41,6 @@ hidden:
   field_service_hours: true
   field_visiting_address: true
   field_visiting_address_additiona: true
+  field_yoast_seo: true
   langcode: true
+  search_api_excerpt: true

--- a/conf/cmi/core.entity_view_display.node.page.default.yml
+++ b/conf/cmi/core.entity_view_display.node.page.default.yml
@@ -10,6 +10,7 @@ dependencies:
     - field.field.node.page.field_hero
     - field.field.node.page.field_layout
     - field.field.node.page.field_liftup_image
+    - field.field.node.page.field_meta_tags
     - field.field.node.page.field_metatags
     - field.field.node.page.field_municipality_info
     - field.field.node.page.field_municipality_selection
@@ -18,9 +19,12 @@ dependencies:
     - field.field.node.page.field_theme_menu_machine_name
     - field.field.node.page.field_url
     - field.field.node.page.field_use_anchor_links
+    - field.field.node.page.field_yoast_seo
     - node.type.page
   module:
+    - metatag
     - user
+    - yoast_seo
 _core:
   default_config_hash: QoKzK_LdQQXrmb4YyhrEEfU-oYAjoKiamaP7nWWRs9A
 id: node.page.default
@@ -28,6 +32,13 @@ targetEntityType: node
 bundle: page
 mode: default
 content:
+  field_metatags:
+    type: metatag_empty_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 2
+    region: content
   field_page_name:
     type: string
     label: inline
@@ -35,6 +46,13 @@ content:
       link_to_entity: false
     third_party_settings: {  }
     weight: 1
+    region: content
+  field_yoast_seo:
+    type: yoastseo_formatter
+    label: above
+    settings: {  }
+    third_party_settings: {  }
+    weight: 3
     region: content
   links:
     settings: {  }
@@ -51,7 +69,7 @@ hidden:
   field_hero: true
   field_layout: true
   field_liftup_image: true
-  field_metatags: true
+  field_meta_tags: true
   field_municipality_info: true
   field_municipality_selection: true
   field_theme_menu: true

--- a/conf/cmi/core.entity_view_display.node.page.teaser.yml
+++ b/conf/cmi/core.entity_view_display.node.page.teaser.yml
@@ -11,6 +11,7 @@ dependencies:
     - field.field.node.page.field_hero
     - field.field.node.page.field_layout
     - field.field.node.page.field_liftup_image
+    - field.field.node.page.field_meta_tags
     - field.field.node.page.field_metatags
     - field.field.node.page.field_municipality_info
     - field.field.node.page.field_municipality_selection
@@ -19,6 +20,7 @@ dependencies:
     - field.field.node.page.field_theme_menu_machine_name
     - field.field.node.page.field_url
     - field.field.node.page.field_use_anchor_links
+    - field.field.node.page.field_yoast_seo
     - node.type.page
   module:
     - user
@@ -50,6 +52,7 @@ hidden:
   field_finnish_title: true
   field_hero: true
   field_layout: true
+  field_meta_tags: true
   field_metatags: true
   field_municipality_info: true
   field_municipality_selection: true
@@ -58,6 +61,7 @@ hidden:
   field_theme_menu_machine_name: true
   field_url: true
   field_use_anchor_links: true
+  field_yoast_seo: true
   langcode: true
   links: true
   search_api_excerpt: true

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -137,6 +137,7 @@ module:
   webform: 0
   webform_rest: 0
   workflows: 0
+  yoast_seo: 0
   helfi_ptv_integration: 1
   inline_entity_form: 1
   paragraphs_asymmetric_translation_widgets: 1

--- a/conf/cmi/field.field.node.article.field_meta_tags.yml
+++ b/conf/cmi/field.field.node.article.field_meta_tags.yml
@@ -1,0 +1,22 @@
+uuid: a09668f7-2153-4e8e-9a72-5be153c7b240
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.article
+  module:
+    - metatag
+id: node.article.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: article
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/conf/cmi/field.field.node.article.field_yoast_seo.yml
+++ b/conf/cmi/field.field.node.article.field_yoast_seo.yml
@@ -1,0 +1,22 @@
+uuid: b85f6f99-9d92-4f0e-8df0-68146261c1ee
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_yoast_seo
+    - node.type.article
+  module:
+    - yoast_seo
+id: node.article.field_yoast_seo
+field_name: field_yoast_seo
+entity_type: node
+bundle: article
+label: 'Real-time SEO'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: yoast_seo

--- a/conf/cmi/field.field.node.landing_page.field_meta_tags.yml
+++ b/conf/cmi/field.field.node.landing_page.field_meta_tags.yml
@@ -1,0 +1,22 @@
+uuid: 1e9e38b7-2b0d-4ff8-a049-bc78783547c4
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.landing_page
+  module:
+    - metatag
+id: node.landing_page.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: landing_page
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/conf/cmi/field.field.node.landing_page.field_yoast_seo.yml
+++ b/conf/cmi/field.field.node.landing_page.field_yoast_seo.yml
@@ -1,0 +1,22 @@
+uuid: 1abd39d8-6d21-459d-8863-e50b0f37eb94
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_yoast_seo
+    - node.type.landing_page
+  module:
+    - yoast_seo
+id: node.landing_page.field_yoast_seo
+field_name: field_yoast_seo
+entity_type: node
+bundle: landing_page
+label: 'Real-time SEO'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: yoast_seo

--- a/conf/cmi/field.field.node.link.field_meta_tags.yml
+++ b/conf/cmi/field.field.node.link.field_meta_tags.yml
@@ -1,0 +1,22 @@
+uuid: 837b9f0a-be8a-4652-9b76-eda0a7e98013
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.link
+  module:
+    - metatag
+id: node.link.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: link
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/conf/cmi/field.field.node.link.field_yoast_seo.yml
+++ b/conf/cmi/field.field.node.link.field_yoast_seo.yml
@@ -1,0 +1,22 @@
+uuid: 59ad33c2-e054-4c4a-bfd2-50700b442342
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_yoast_seo
+    - node.type.link
+  module:
+    - yoast_seo
+id: node.link.field_yoast_seo
+field_name: field_yoast_seo
+entity_type: node
+bundle: link
+label: 'Real-time SEO'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: yoast_seo

--- a/conf/cmi/field.field.node.message.field_meta_tags.yml
+++ b/conf/cmi/field.field.node.message.field_meta_tags.yml
@@ -1,0 +1,22 @@
+uuid: fa4aa6b4-0dbf-4dcc-ae2d-ffdd22f5e303
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.message
+  module:
+    - metatag
+id: node.message.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: message
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/conf/cmi/field.field.node.message.field_yoast_seo.yml
+++ b/conf/cmi/field.field.node.message.field_yoast_seo.yml
@@ -1,0 +1,22 @@
+uuid: 68ed808f-8833-4e97-846a-dfcf356f5c41
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_yoast_seo
+    - node.type.message
+  module:
+    - yoast_seo
+id: node.message.field_yoast_seo
+field_name: field_yoast_seo
+entity_type: node
+bundle: message
+label: 'Real-time SEO'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: yoast_seo

--- a/conf/cmi/field.field.node.office_contact_info.field_meta_tags.yml
+++ b/conf/cmi/field.field.node.office_contact_info.field_meta_tags.yml
@@ -1,0 +1,22 @@
+uuid: 776d523c-7a16-4d04-85a9-239530ac9e7b
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.office_contact_info
+  module:
+    - metatag
+id: node.office_contact_info.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: office_contact_info
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/conf/cmi/field.field.node.office_contact_info.field_yoast_seo.yml
+++ b/conf/cmi/field.field.node.office_contact_info.field_yoast_seo.yml
@@ -1,0 +1,22 @@
+uuid: 03a057a5-6a31-45f1-91b7-96513550fc8c
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_yoast_seo
+    - node.type.office_contact_info
+  module:
+    - yoast_seo
+id: node.office_contact_info.field_yoast_seo
+field_name: field_yoast_seo
+entity_type: node
+bundle: office_contact_info
+label: 'Real-time SEO'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: yoast_seo

--- a/conf/cmi/field.field.node.page.field_meta_tags.yml
+++ b/conf/cmi/field.field.node.page.field_meta_tags.yml
@@ -1,0 +1,22 @@
+uuid: ae17e40f-40d2-4f7e-b854-dfbb5319b514
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_meta_tags
+    - node.type.page
+  module:
+    - metatag
+id: node.page.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+bundle: page
+label: 'Meta tags'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: metatag

--- a/conf/cmi/field.field.node.page.field_yoast_seo.yml
+++ b/conf/cmi/field.field.node.page.field_yoast_seo.yml
@@ -1,0 +1,22 @@
+uuid: 6a2ffc61-f835-4866-b26c-fd405f2a7205
+langcode: fi
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_yoast_seo
+    - node.type.page
+  module:
+    - yoast_seo
+id: node.page.field_yoast_seo
+field_name: field_yoast_seo
+entity_type: node
+bundle: page
+label: 'Real-time SEO'
+description: ''
+required: false
+translatable: true
+skip_translation_check: null
+default_value: {  }
+default_value_callback: ''
+settings: {  }
+field_type: yoast_seo

--- a/conf/cmi/field.storage.node.field_meta_tags.yml
+++ b/conf/cmi/field.storage.node.field_meta_tags.yml
@@ -1,0 +1,19 @@
+uuid: 00985cf6-fd7e-46ce-83b0-56d4fee6e31d
+langcode: fi
+status: true
+dependencies:
+  module:
+    - metatag
+    - node
+id: node.field_meta_tags
+field_name: field_meta_tags
+entity_type: node
+type: metatag
+settings: {  }
+module: metatag
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/field.storage.node.field_yoast_seo.yml
+++ b/conf/cmi/field.storage.node.field_yoast_seo.yml
@@ -1,0 +1,19 @@
+uuid: 92f6d7c9-6612-4ce2-8e0f-84c34f3d4279
+langcode: fi
+status: true
+dependencies:
+  module:
+    - node
+    - yoast_seo
+id: node.field_yoast_seo
+field_name: field_yoast_seo
+entity_type: node
+type: yoast_seo
+settings: {  }
+module: yoast_seo
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/conf/cmi/yoast_seo.settings.yml
+++ b/conf/cmi/yoast_seo.settings.yml
@@ -1,0 +1,5 @@
+score_rules:
+  0: 'Not available'
+  8: Good
+  1: Bad
+  5: Okay


### PR DESCRIPTION
First run the following commands, `drush cr` , `composer install`, `drush cr` and `drush cim` . Might need to run `cr` after the `cim`.

This PR is related to this [IFU-817](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IFU/boards/198/backlog?view=detail&selectedIssue=IFU-817&issueLimit=100) ticket. Hopefully I got all the config files into this PR/ticket, there were quite a lot of them. 

Installed and enabled the Real-time SEO module, so you can edit the Google Metadata description by hand (if needed). So if you open an article, landing page or basic page, you should be able to see this at the bottom of the edit page. 

![Screenshot 2023-09-11 at 12-03-38 Edit Basic page Koulutus Helsingissä InfoFinland](https://github.com/City-of-Helsinki/drupal-infofinland/assets/131336019/c835dcf2-0357-4fb2-9d85-b84d5e3c7d14)

To test this, you can open an article or basic page and then go to edit, edit the description meta and save it. Then open the article or basic page again and open inspector and see that the new/edited description is showing between the `head` tags.

EDIT: There still might be a problem with the config files, that I didn't get them all to this PR. I tried this PR today (tuesday, 12.8.2023). I think it worked like it should, but then when I was returning / checkout to develop branch and tried to run `drush cim` and `drush updb`, it gave me an error about this module that we install on this PR. Might be that I didn't run `composer install` .

[IFU-817]: https://helsinkisolutionoffice.atlassian.net/browse/IFU-817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ