### PR TITLE
Feature/ifu-893 hide env indicator

### DIFF
--- a/conf/cmi/user.role.authenticated.yml
+++ b/conf/cmi/user.role.authenticated.yml
@@ -3,14 +3,9 @@ langcode: en
 status: true
 dependencies:
   config:
-    - environment_indicator.switcher.development
-    - environment_indicator.switcher.production
-    - environment_indicator.switcher.stage
-    - environment_indicator.switcher.test
     - filter.format.full_html
     - filter.format.simple_html
   module:
-    - environment_indicator
     - filter
     - legal
     - media
@@ -24,11 +19,6 @@ weight: 1
 is_admin: false
 permissions:
   - 'access content'
-  - 'access environment indicator'
-  - 'access environment indicator development'
-  - 'access environment indicator production'
-  - 'access environment indicator stage'
-  - 'access environment indicator test'
   - 'use text format full_html'
   - 'use text format simple_html'
   - 'view Terms and Conditions'

--- a/conf/cmi/user.role.infofinland_admin.yml
+++ b/conf/cmi/user.role.infofinland_admin.yml
@@ -3,6 +3,10 @@ langcode: en
 status: true
 dependencies:
   config:
+    - environment_indicator.switcher.development
+    - environment_indicator.switcher.production
+    - environment_indicator.switcher.stage
+    - environment_indicator.switcher.test
     - media.type.file
     - media.type.image
     - media.type.remote_video
@@ -22,6 +26,7 @@ dependencies:
     - content_moderation
     - content_translation
     - entity_browser
+    - environment_indicator
     - file
     - filter
     - language
@@ -51,6 +56,11 @@ is_admin: null
 permissions:
   - 'access administration pages'
   - 'access content overview'
+  - 'access environment indicator'
+  - 'access environment indicator development'
+  - 'access environment indicator production'
+  - 'access environment indicator stage'
+  - 'access environment indicator test'
   - 'access files overview'
   - 'access media overview'
   - 'access media_entity_browser_modal entity browser pages'


### PR DESCRIPTION
The Jira ticket is straightforward. 

There's an environment indicator at the top of the page which has links and should be hidden from people without permissions to other environments. This PR should change the permissions so only Yllapitaja and InforfinlandYllapitaja should have access.

To test, 
- log in as the above roles and see that the environment bar is visible. 
- log in as anyone else and see that it's not visible.