### PR TITLE
IFU-591 - limited the autocomplete for linkit and menu items

### DIFF
--- a/conf/cmi/linkit.linkit_profile.helfi.yml
+++ b/conf/cmi/linkit.linkit_profile.helfi.yml
@@ -15,7 +15,9 @@ matchers:
     uuid: 49b7eb26-ed0f-47be-8b6b-3c2ab7a70069
     settings:
       metadata: 'by [node:author] | [node:created:medium]'
-      bundles: {  }
+      bundles:
+        landing_page: landing_page
+        page: page
       group_by_bundle: false
       substitution_type: canonical
       limit: 100

--- a/public/modules/custom/infofinland_common/infofinland_common.module
+++ b/public/modules/custom/infofinland_common/infofinland_common.module
@@ -62,6 +62,14 @@ function infofinland_common_form_alter(array &$form, FormStateInterface $form_st
       $form['admin_metainformation']['#access'] = FALSE;
     }
   }
+
+  // Limit the autocomplete widget on the menu link page to only landing pages and basic pages.
+  if ($form_id === 'menu_link_content_menu_link_content_form') {
+    $form['link']['widget'][0]['uri']['#selection_handler'] = "default:node";
+    $form['link']['widget'][0]['uri']['#selection_settings'] = [
+      'target_bundles' => ['landing_page' => 'landing_page', 'page' => 'page'], //etc
+    ];
+  }
 }
 
 /**


### PR DESCRIPTION
Limited the autocomplete for linkit and menu items to only landing pages and basic pages.

To test:
- Try to add a link to a piece of content using CKeditor and verify that the list of suggestions includes only landing pages and basic pages (e.g. Swedish Language Courses is a linkkipankki link and shouldn't appear)
- Rinse and Repeat for menu items