### PR TITLE
IFU-893: hotfix/IFU-893: Changed the url for stage env

### DIFF
--- a/conf/cmi/environment_indicator.switcher.stage.yml
+++ b/conf/cmi/environment_indicator.switcher.stage.yml
@@ -6,6 +6,6 @@ machine: stage
 description: null
 name: Stage
 weight: '2'
-url: 'https://infofinland-edit.stage.hel.ninja/'
+url: 'https://edit-infofinland.stage.hel.ninja'
 fg_color: '#000000'
 bg_color: '#3584e4'

--- a/public/sites/default/env.indicator.settings.php
+++ b/public/sites/default/env.indicator.settings.php
@@ -9,7 +9,7 @@ switch ($_SERVER['HTTP_HOST']) {
 		$config['environment_indicator.indicator']['fg_color'] = '#000000';
 		$config['environment_indicator.indicator']['name'] = 'Production';
 		break;
-	case 'infofinland-edit.stage.hel.ninja':
+	case 'edit-infofinland.stage.hel.ninja':
 		$config['environment_indicator.indicator']['bg_color'] = '#3584e4';
 		$config['environment_indicator.indicator']['fg_color'] = '#000000';
 		$config['environment_indicator.indicator']['name'] = 'Stage';


### PR DESCRIPTION
First run the following commands, `drush cr` , `drush cim -y` and `drush cr` again.

Basically you don't need to test this, just check that the url's have changed. The right url at the moment is, `https://edit-infofinland.stage.hel.ninja`