### PR TITLE
bugfix/IFU-909: Fixed a typo on infofinland_gdpr custom module

### DIFF
--- a/public/modules/custom/infofinland_gdpr/src/EventSubscriber/InfofinlandGdprSubscriber.php
+++ b/public/modules/custom/infofinland_gdpr/src/EventSubscriber/InfofinlandGdprSubscriber.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Infofinland_gdpr\EventSubscriber;
+namespace Drupal\infofinland_gdpr\EventSubscriber;
 
 use Symfony\Component\HttpKernel\KernelEvents;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;


### PR DESCRIPTION
This PR refers to this ticket [IFU-909](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IFU/boards/198/backlog?selectedIssue=IFU-909).

During the php unit tests, I discovered that there was a bug/typo on the custom `infofinland_gdpr` module.

There was error on the namespace of the `InfofinlandGdprSubscriber.php` file, because `Infofinland_gdpr` should be all on lower case, so I fixed that and the unit test started to work with out the `RuntimeException: Case mismatch between loaded and declared class names` error.

[IFU-909]: https://helsinkisolutionoffice.atlassian.net/browse/IFU-909?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ