### PR TITLE
IFU-913: Changed the SMTP server address

### DIFF
--- a/conf/cmi/smtp.settings.yml
+++ b/conf/cmi/smtp.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: 2v5R3I9tNatGzKQjuZWh1y_955xK09313Vn-IIuedyI
 smtp_on: false
-smtp_host: ema.platta-net.hel.fi
+smtp_host: relay.hel.fi
 smtp_hostbackup: ''
 smtp_port: '25'
 smtp_protocol: standard


### PR DESCRIPTION
Like the [IFU-913](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IFU/boards/198/backlog?selectedIssue=IFU-913) ticket says we need to change the old SMTP server address, because they are shutting down the server.  The ticket it self tells us to change [ema.hel.fi](http://ema.hel.fi/) to [relay.hel.fi](http://relay.hel.fi/), because that's the new server. The deadline is that these changes should be made at, November the 3rd. 

What seemed a bit odd, is that the current server address that we had on Drupal, had an address of `ema.platta-net.hel.fi` and not `ema.hel.fi`, so basically I hope that the new server address also works for us. Although the current address is different, it seems to work, because we got the request to change the SMTP server address.

To test this, run the following command `drush cim -y` and `drush cr` , then go to `/fi/admin/config/system/smtp`.  There, see that the SMTP server settings has the new address on SMTP server field. So the new address should be `relay.hel.fi`.

 

[IFU-913]: https://helsinkisolutionoffice.atlassian.net/browse/IFU-913?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ