### PR TITLE
IFU-904: Installed and enabled the anonymous_login module

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
         "cweagans/composer-patches": "^1.6.7",
         "drupal/adv_varnish": "^4.0",
         "drupal/allowed_formats": "^1.5",
+        "drupal/anonymous_login": "^2.1",
         "drupal/ckeditor_bidi": "^3.1",
         "drupal/color_field": "^2.5",
         "drupal/config_ignore": "^2.3",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c22406e9c5a54dbc2d011561e5096f35",
+    "content-hash": "81192026194acd07c5aa66fd589dae57",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1649,6 +1649,61 @@
             "support": {
                 "source": "http://cgit.drupalcode.org/allowed_formats",
                 "issues": "https://www.drupal.org/project/issues/allowed_formats"
+            }
+        },
+        {
+            "name": "drupal/anonymous_login",
+            "version": "2.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/anonymous_login.git",
+                "reference": "8.x-2.1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/anonymous_login-8.x-2.1.zip",
+                "reference": "8.x-2.1",
+                "shasum": "7144f97b68080b9ad7201717278e3fc41f15dde8"
+            },
+            "require": {
+                "drupal/core": "^9.2 || ^10"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "drupal": {
+                    "version": "8.x-2.1",
+                    "datestamp": "1670969782",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                },
+                "branch-alias": {
+                    "dev-8.x-2.x": "2.x-dev"
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "andrew_tspkh",
+                    "homepage": "https://www.drupal.org/user/3302731"
+                },
+                {
+                    "name": "japerry",
+                    "homepage": "https://www.drupal.org/user/45640"
+                },
+                {
+                    "name": "mstef",
+                    "homepage": "https://www.drupal.org/user/107190"
+                }
+            ],
+            "description": "Specify pages that when visited by anonymous users will be forced to login.",
+            "homepage": "https://www.drupal.org/project/anonymous_login",
+            "support": {
+                "source": "https://git.drupalcode.org/project/anonymous_login"
             }
         },
         {

--- a/conf/cmi/anonymous_login.settings.yml
+++ b/conf/cmi/anonymous_login.settings.yml
@@ -1,0 +1,5 @@
+_core:
+  default_config_hash: ZKVq7lpyGFQf-SCuj_Ng2yLPD24rKHxz-TzGQxBjLl4
+paths: '*'
+login_path: /user/login
+message: ''

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -5,6 +5,7 @@ module:
   admin_toolbar_links_access_filter: 0
   admin_toolbar_tools: 0
   allowed_formats: 0
+  anonymous_login: 0
   block: 0
   breakpoint: 0
   ckeditor: 0


### PR DESCRIPTION
This ticket refers to [IFU-904](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IFU/boards/198?selectedIssue=IFU-904). The problem was that anonymous users can see the content from the backend. So I installed and enabled new module, that should prevent that. So the content is only visible to logged in users. 

To test this, run the following commands, `composer install` , `drush cim -y` and `drush cr`.

So basically you don't have to be even logged in, but you probably are with Chrome, but try for example Safari (see that you're not logged in) and go to your local ddev url for this project. It should now redirect you to the login page. 

I also test this with my local, if I create a dummy user and try to login from that login form, that it's actually works. Edit: the login works with dummy user.

[IFU-904]: https://helsinkisolutionoffice.atlassian.net/browse/IFU-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ