### PR TITLE
Bugfix/ifu 895 reapplying gdpr

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -23,6 +23,7 @@ module:
   crop: 0
   ctools: 0
   datetime: 0
+  dblog: 0
   decoupled_router: 0
   default_content: 0
   diff: 0
@@ -41,6 +42,7 @@ module:
   field_group: 0
   field_ui: 0
   file: 0
+  filelog: 0
   filter: 0
   flysystem: 0
   flysystem_azure: 0

--- a/conf/cmi/dblog.settings.yml
+++ b/conf/cmi/dblog.settings.yml
@@ -1,0 +1,3 @@
+_core:
+  default_config_hash: e883aGsrt1wFrsydlYU584PZONCSfRy0DtkZ9KzHb58
+row_limit: 1000

--- a/conf/cmi/filelog.settings.yml
+++ b/conf/cmi/filelog.settings.yml
@@ -1,0 +1,13 @@
+_core:
+  default_config_hash: uVSFqX1MwFixVjXjlh72ukQ8LKPgMKNi2raycY9vt3w
+enabled: true
+location: 'public://logs'
+rotation:
+  schedule: daily
+  delete: false
+  destination: 'archive/[date:custom:Y/m/d].log'
+  gzip: true
+format: '[[log:created]] [[log:level]] [[log:channel]] [client: [log:ip], [log:user]] [log:message]'
+level: 7
+channels_type: exclude
+channels: {  }


### PR DESCRIPTION
The dblog was enabled to make possible to track when a user's page is visited. 
Filelog was also enabled and made an actual file - this one may not be needed.

Both modules were removed recently and this PR should put them back in place.

To test:
- Visit a user profile. Click "edit" just for good measure.
- Check `/en/admin/reports/dblog` - you should see a note of it