### PR TITLE
IFU-932: Install and enable EU Cookie compliance, banner is hidden, because it needs styling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,7 @@
         "drupal/core-recommended": "^9",
         "drupal/crop": "^2.2",
         "drupal/environment_indicator": "^4.0",
+        "drupal/eu_cookie_compliance": "^1.24",
         "drupal/features": "^3.13",
         "drupal/filelog": "^2.1",
         "drupal/hdbt": "^5.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ee4cc3c689d4e21bd6a39bdaf2614d15",
+    "content-hash": "214eb6a9fb177dacdcadb5346390f1a9",
     "packages": [
         {
             "name": "asm89/stack-cors",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -145,6 +145,7 @@ module:
   views: 10
   paragraphs: 11
   minimal: 1000
+  eu_cookie_compliance: 1001
 theme:
   stark: 0
   stable9: 0

--- a/conf/cmi/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/eu_cookie_compliance.settings.yml
@@ -1,0 +1,86 @@
+_core:
+  default_config_hash: zmkyvoZ03LGqfVeB0mtslC-pkWMOrGIU9lJl9_jqUkc
+langcode: en
+uuid: 912ab97f-3481-40ef-ae25-4d9c6802f58e
+popup_enabled: false
+popup_clicking_confirmation: false
+popup_scrolling_confirmation: false
+eu_countries: {  }
+eu_only: false
+eu_only_js: false
+popup_position: false
+fixed_top_position: true
+popup_info:
+  value: "<h2>Infofinland.fi uses cookies</h2>\r\n\r\n<p>This site uses necessary cookies to ensure performance and to monitor general usage. In addition, we use targeting cookies to improve the user experience.</p>\r\n"
+  format: full_html
+mobile_popup_info:
+  value: ''
+  format: full_html
+popup_info_template: new
+popup_agree_button_message: Accept
+popup_more_info_button_message: 'More info'
+mobile_breakpoint: 768
+popup_agreed_enabled: false
+popup_hide_agreed: false
+disagree_button_label: 'No, thanks'
+popup_agreed:
+  value: "<h2>Thank you for accepting cookies</h2>\r\n\r\n<p>You can now hide this message or find out more about cookies.</p>\r\n"
+  format: full_html
+popup_find_more_button_message: 'More info'
+popup_hide_button_message: Hide
+popup_link: 'https://infofinland.fi/cookie-settings'
+popup_link_new_window: true
+popup_height: null
+popup_width: 100%
+popup_delay: 1000
+show_more_info: true
+popup_bg_hex: ffffff
+popup_text_hex: 1a1a1a
+domain: ''
+domains_option: 1
+domains_list: ''
+exclude_paths: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
+exclude_admin_theme: false
+cookie_session: 0
+set_cookie_session_zero_on_disagree: 0
+cookie_lifetime: 100
+use_mobile_message: false
+use_bare_css: false
+use_olivero_css: true
+disagree_do_not_show_popup: false
+reload_page: false
+reload_options: 0
+reload_routes_list: ''
+cookie_name: ''
+exclude_uid_1: false
+better_support_for_screen_readers: false
+method: opt_in
+disabled_javascripts: ''
+automatic_cookies_removal: true
+allowed_cookies: ''
+consent_storage_method: do_not_store
+withdraw_message:
+  value: "<h2>We use cookies on this site to enhance your user experience</h2>\r\n\r\n<p>You have given your consent for us to set cookies.</p>\r\n"
+  format: full_html
+withdraw_tab_button_label: 'Privacy settings'
+withdraw_action_button_label: 'Withdraw consent'
+withdraw_enabled: false
+withdraw_button_on_info_popup: false
+save_preferences_button_label: 'Save preferences'
+accept_all_categories_button_label: 'Accept all cookies'
+enable_save_preferences_button: true
+domain_all_sites: false
+settings_tab_enabled: false
+containing_element: body
+cookie_policy_version: 1.0.0
+cookie_value_disagreed: '0'
+cookie_value_agreed_show_thank_you: '1'
+cookie_value_agreed: '2'
+accessibility_focus: false
+close_button_action: close_banner
+reject_button_label: ''
+reject_button_enabled: false
+close_button_enabled: false
+dependencies:
+  config:
+    - filter.format.full_html


### PR DESCRIPTION
This is a test to see, if this fixes the following error and to see, if it fixes the 504 timeout error.

`User warning: The following theme is missing from the file system: eu_cookie_compliance in Drupal\Core\Extension\ExtensionPathResolver->getPathname() (line 63 of core/lib/Drupal/Core/Extension/ExtensionPathResolver.php).`

The banner itself is not enabled, because it needs styling and I thought it would be wise to test it first if it fixes even one of those errors.