### PR TITLE
IFU-933: Dummy modules

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
         "drupal/core-recommended": "^9",
         "drupal/crop": "^2.2",
         "drupal/environment_indicator": "^4.0",
-        "drupal/eu_cookie_compliance": "^1.24",
         "drupal/features": "^3.13",
         "drupal/filelog": "^2.1",
         "drupal/hdbt": "^5.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "214eb6a9fb177dacdcadb5346390f1a9",
+    "content-hash": "ee4cc3c689d4e21bd6a39bdaf2614d15",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -1624,16 +1624,8 @@
                     "homepage": "https://www.drupal.org/user/46549"
                 },
                 {
-                    "name": "googletorp",
-                    "homepage": "https://www.drupal.org/user/386230"
-                },
-                {
                     "name": "jsacksick",
                     "homepage": "https://www.drupal.org/user/972218"
-                },
-                {
-                    "name": "mglaman",
-                    "homepage": "https://www.drupal.org/user/2416470"
                 },
                 {
                     "name": "rszrama",
@@ -1761,7 +1753,7 @@
             ],
             "authors": [
                 {
-                    "name": "claymor",
+                    "name": "m.krestnicov",
                     "homepage": "https://www.drupal.org/user/3193903"
                 },
                 {
@@ -3245,6 +3237,10 @@
                     "name": "Greg Boggs",
                     "homepage": "https://www.drupal.org/u/greg-boggs",
                     "role": "Maintainer"
+                },
+                {
+                    "name": "Greg Boggs",
+                    "homepage": "https://www.drupal.org/user/153069"
                 },
                 {
                     "name": "hmartens",
@@ -15078,16 +15074,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.4.0",
+            "version": "v6.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "b45fcf399ea9c3af543a92edf7172ba21174d809"
+                "reference": "7cb80bc10bfcdf6b5492741c0b9357dac66940bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/b45fcf399ea9c3af543a92edf7172ba21174d809",
-                "reference": "b45fcf399ea9c3af543a92edf7172ba21174d809",
+                "url": "https://api.github.com/repos/symfony/string/zipball/7cb80bc10bfcdf6b5492741c0b9357dac66940bc",
+                "reference": "7cb80bc10bfcdf6b5492741c0b9357dac66940bc",
                 "shasum": ""
             },
             "require": {
@@ -15144,7 +15140,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.4.0"
+                "source": "https://github.com/symfony/string/tree/v6.4.2"
             },
             "funding": [
                 {
@@ -15160,7 +15156,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-11-28T20:41:49+00:00"
+            "time": "2023-12-10T16:15:48+00:00"
         },
         {
             "name": "symfony/translation",
@@ -16073,26 +16069,28 @@
     "packages-dev": [
         {
             "name": "behat/mink",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/minkphp/Mink.git",
-                "reference": "19e58905632e7cfdc5b2bafb9b950a3521af32c5"
+                "reference": "d8527fdf8785aad38455fb426af457ab9937aece"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/minkphp/Mink/zipball/19e58905632e7cfdc5b2bafb9b950a3521af32c5",
-                "reference": "19e58905632e7cfdc5b2bafb9b950a3521af32c5",
+                "url": "https://api.github.com/repos/minkphp/Mink/zipball/d8527fdf8785aad38455fb426af457ab9937aece",
+                "reference": "d8527fdf8785aad38455fb426af457ab9937aece",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.2",
-                "symfony/css-selector": "^4.4 || ^5.0 || ^6.0"
+                "symfony/css-selector": "^4.4 || ^5.0 || ^6.0 || ^7.0"
             },
             "require-dev": {
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-phpunit": "^1.3",
                 "phpunit/phpunit": "^8.5.22 || ^9.5.11",
-                "symfony/error-handler": "^4.4 || ^5.0 || ^6.0",
-                "symfony/phpunit-bridge": "^5.4 || ^6.0"
+                "symfony/error-handler": "^4.4 || ^5.0 || ^6.0 || ^7.0",
+                "symfony/phpunit-bridge": "^5.4 || ^6.0 || ^7.0"
             },
             "suggest": {
                 "behat/mink-browserkit-driver": "fast headless driver for any app without JS emulation",
@@ -16131,9 +16129,9 @@
             ],
             "support": {
                 "issues": "https://github.com/minkphp/Mink/issues",
-                "source": "https://github.com/minkphp/Mink/tree/v1.10.0"
+                "source": "https://github.com/minkphp/Mink/tree/v1.11.0"
             },
-            "time": "2022-03-28T14:22:43+00:00"
+            "time": "2023-12-09T11:23:23+00:00"
         },
         {
             "name": "behat/mink-selenium2-driver",

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -150,6 +150,7 @@ module:
   views: 10
   paragraphs: 11
   minimal: 1000
+  eu_cookie_compliance: 1001
 theme:
   stark: 0
   stable9: 0

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -49,7 +49,11 @@ module:
   focal_point: 0
   gin_toolbar: 0
   hal: 0
+  hdbt_admin_editorial: 0
   hdbt_admin_tools: 0
+  hdbt_component_library: 0
+  hdbt_content: 0
+  hdbt_hyphenopoly: 0
   health_check: 0
   helfi_api_base: 0
   helfi_azure_fs: 0
@@ -113,6 +117,7 @@ module:
   scheduler: 0
   search_api: 0
   select2: 0
+  select2_icon: 0
   serialization: 0
   simple_oauth: 0
   simple_sitemap: 0
@@ -145,7 +150,6 @@ module:
   views: 10
   paragraphs: 11
   minimal: 1000
-  eu_cookie_compliance: 1001
 theme:
   stark: 0
   stable9: 0

--- a/conf/cmi/eu_cookie_compliance.settings.yml
+++ b/conf/cmi/eu_cookie_compliance.settings.yml
@@ -1,7 +1,7 @@
 _core:
   default_config_hash: zmkyvoZ03LGqfVeB0mtslC-pkWMOrGIU9lJl9_jqUkc
 langcode: en
-uuid: 912ab97f-3481-40ef-ae25-4d9c6802f58e
+uuid: 1d24206c-c1cb-44bc-bf7a-bc8a0fc8d69e
 popup_enabled: false
 popup_clicking_confirmation: false
 popup_scrolling_confirmation: false
@@ -11,7 +11,7 @@ eu_only_js: false
 popup_position: false
 fixed_top_position: true
 popup_info:
-  value: "<h2>Infofinland.fi uses cookies</h2>\r\n\r\n<p>This site uses necessary cookies to ensure performance and to monitor general usage. In addition, we use targeting cookies to improve the user experience.</p>\r\n"
+  value: "<h2>Infofinland.fi uses cookies</h2>\r\n\r\n<p></p>\r\n\r\n<p>This site uses necessary cookies to ensure performance and to monitor general usage. In addition, we use targeting cookies to improve the user experience.</p>\r\n\r\n<p></p>\r\n"
   format: full_html
 mobile_popup_info:
   value: ''

--- a/public/modules/custom/hdbt_admin_editorial/hdbt_admin_editorial.info.yml
+++ b/public/modules/custom/hdbt_admin_editorial/hdbt_admin_editorial.info.yml
@@ -1,0 +1,6 @@
+name: HDBT - Admin Editorial
+type: module
+description: Dummy module
+package: custom
+core: 8.x
+core_version_requirement: ^8 || ^9 || ^10

--- a/public/modules/custom/hdbt_component_library/hdbt_component_library.info.yml
+++ b/public/modules/custom/hdbt_component_library/hdbt_component_library.info.yml
@@ -1,0 +1,6 @@
+name: HDBT - Component Library
+type: module
+description: Dummy module
+package: custom
+core: 8.x
+core_version_requirement: ^8 || ^9 || ^10

--- a/public/modules/custom/hdbt_content/hdbt_content.info.yml
+++ b/public/modules/custom/hdbt_content/hdbt_content.info.yml
@@ -1,0 +1,6 @@
+name: HDBT - Content
+type: module
+description: Dummy module
+package: custom
+core: 8.x
+core_version_requirement: ^8 || ^9 || ^10

--- a/public/modules/custom/hdbt_hyphenopoly/hdbt_hyphenopoly.info.yml
+++ b/public/modules/custom/hdbt_hyphenopoly/hdbt_hyphenopoly.info.yml
@@ -1,0 +1,6 @@
+name: HDBT - Hyphenopoly
+type: module
+description: Dummy module
+package: custom
+core: 8.x
+core_version_requirement: ^8 || ^9 || ^10

--- a/public/modules/custom/select2_icon/select2_icon.info.yml
+++ b/public/modules/custom/select2_icon/select2_icon.info.yml
@@ -1,0 +1,6 @@
+name: Select2 Icon
+type: module
+description: Dummy module
+package: custom
+core: 8.x
+core_version_requirement: ^8 || ^9 || ^10


### PR DESCRIPTION
This PR relates to this [ticket](https://helsinkisolutionoffice.atlassian.net/jira/software/c/projects/IFU/boards/198?selectedIssue=IFU-933).

When upgrading the hdbt themes and helfi modules, something has gone wrong, somewhere during the update process. These modules or packages caused some problems, that even the `cim` command, didn't run on local and it like ended up with broken local and develop environment. 

 * hdbt_admin_editorial
 * hdbt_component_library
 * hdbt_content
 * hdbt_hyphenopoly
 * select2_icon
 
So I created dummy modules for the ones that got removed after `platform_config` v. 3.x, (for those above) and now it seems that the `cim` runs.  Also removed the `eu_cookie_compliance` module from the root `composer.json` file, because it comes from the `platform_config` module.