### PR TITLE
IFU-925: Restore the drupal-php-docker image versions to 8.2

### DIFF
--- a/.github/workflows/artifact.yml
+++ b/.github/workflows/artifact.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/city-of-helsinki/drupal-php-docker:8.1-alpine
+      image: ghcr.io/city-of-helsinki/drupal-php-docker:8.2-alpine
 
     services:
       db:

--- a/.github/workflows/test.yml.dist
+++ b/.github/workflows/test.yml.dist
@@ -10,7 +10,7 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/city-of-helsinki/drupal-php-docker:8.1-alpine
+      image: ghcr.io/city-of-helsinki/drupal-php-docker:8.2-alpine
       options: --hostname app
 
     services:

--- a/.github/workflows/update-config.yml
+++ b/.github/workflows/update-config.yml
@@ -7,7 +7,7 @@ jobs:
   update-config:
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/city-of-helsinki/drupal-php-docker:8.1-alpine
+      image: ghcr.io/city-of-helsinki/drupal-php-docker:8.2-alpine
 
     services:
       db:


### PR DESCRIPTION
Restore the workflow drupal-php-docker image versions to 8.2 instead of 8.1.