### PR TITLE
UHF-9770: Reassign node revisions to anonymous in database before canceling user.

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -55,6 +55,7 @@ module:
   infofinland_common: 0
   infofinland_gdpr: 0
   infofinland_permissions: 0
+  infofinland_user_cancel: 0
   jsonapi: 0
   jsonapi_extras: 0
   jsonapi_menu_items: 0

--- a/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.info.yml
+++ b/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.info.yml
@@ -1,0 +1,5 @@
+name: InfoFinland user cancel
+description: 'Fixes related to deleting or canceling users.'
+package: 'Custom'
+type: module
+core_version_requirement: ^9 || ^10

--- a/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
+++ b/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
@@ -1,4 +1,10 @@
 <?php
+
+/**
+ * @file
+ * Helper functions related to deleting user accounts.
+ */
+
 use Drupal\user\UserInterface;
 
 /**
@@ -24,36 +30,36 @@ function infofinland_user_cancel_user_cancel($edit, UserInterface $account, $met
  */
 function _infofinland_user_cancel_reassign_nodes_to_anonymous(UserInterface $account): void {
 
-    $database = \Drupal::database();
-    $tables = [
-      'node_field_data' => 'uid',
-      'node_field_revision' => 'uid',
-      'node_revision' => 'revision_uid',
-    ];
+  $database = \Drupal::database();
+  $tables = [
+    'node_field_data' => 'uid',
+    'node_field_revision' => 'uid',
+    'node_revision' => 'revision_uid',
+  ];
 
-    $user_id = $account->id();
-    foreach ($tables as $table => $uid_field) {
-      $matches = $database->select($table)
-        ->condition($uid_field, $user_id)
-        ->countQuery()
-        ->execute()
-        ->fetchField();
+  $user_id = $account->id();
+  foreach ($tables as $table => $uid_field) {
+    $matches = $database->select($table)
+      ->condition($uid_field, $user_id)
+      ->countQuery()
+      ->execute()
+      ->fetchField();
 
-      if ((int) $matches < 1) {
-        continue;
-      }
-
-      $database->update($table)
-        ->fields([$uid_field => 0])
-        ->condition($uid_field, $user_id)
-        ->execute();
-      \Drupal::logger('infofinland_user_cancel')->notice(t('Set @count rows from @table to 0 from @uid',
-        [
-          '@count' => $matches,
-          '@table' => $table,
-          '@uid' => $user_id,
-        ]
-      ));
+    if ((int) $matches < 1) {
+      continue;
     }
 
+    $database->update($table)
+      ->fields([$uid_field => 0])
+      ->condition($uid_field, $user_id)
+      ->execute();
+    \Drupal::logger('infofinland_user_cancel')->notice(t('Set @count rows from @table to 0 from @uid',
+      [
+        '@count' => $matches,
+        '@table' => $table,
+        '@uid' => $user_id,
+      ]
+    ));
   }
+
+}

--- a/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
+++ b/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
@@ -3,12 +3,17 @@
 /**
  * @file
  * Helper functions related to deleting user accounts.
+ *
+ * This is in a separate module so it can be turned off easier
+ * and we can reassign module weights / run order if necessary.
  */
 
 use Drupal\user\UserInterface;
 
 /**
  * Implements hook_user_cancel().
+ *
+ * This has to run before node module's user_cancel hook.
  */
 function infofinland_user_cancel_user_cancel($edit, UserInterface $account, $method) {
   switch ($method) {
@@ -22,8 +27,7 @@ function infofinland_user_cancel_user_cancel($edit, UserInterface $account, $met
 /**
  * Reassigns all node revisions by $account to by owned by anonymous (uid 0).
  *
- * Replicating functionality of node module, because node code is intended to
- * be run from a form or otherwise batched.
+ * Prevents crashes and timeouts when revisions are handled by node module hook.
  *
  * @param \Drupal\user\UserInterface $account
  *   The user.

--- a/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
+++ b/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
@@ -11,6 +11,20 @@
 use Drupal\user\UserInterface;
 
 /**
+ * Implements hook_module_implements_alter().
+ */
+function infofinland_user_cancel_module_implements_alter(&$implementations, $hook) : void {
+  // Move infofinland_user_cancel_user_cancel() implementation to the top of the
+  // list, so this is always run first before any other alter hooks, more
+  // specifically before 'node_user_cancel()' which causes issues when mass
+  // reassigning node revisions.
+  if ($hook === 'user_cancel') {
+    $group = $implementations['infofinland_user_cancel'];
+    $implementations = ['infofinland_user_cancel' => $group] + $implementations;
+  }
+}
+
+/**
  * Implements hook_user_cancel().
  *
  * This has to run before node module's user_cancel hook.

--- a/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
+++ b/public/modules/custom/infofinland_user_cancel/infofinland_user_cancel.module
@@ -1,0 +1,59 @@
+<?php
+use Drupal\user\UserInterface;
+
+/**
+ * Implements hook_user_cancel().
+ */
+function infofinland_user_cancel_user_cancel($edit, UserInterface $account, $method) {
+  switch ($method) {
+    case 'user_cancel_reassign':
+      // Anonymize all of the nodes for this old account.
+      _infofinland_user_cancel_reassign_nodes_to_anonymous($account);
+      break;
+  }
+}
+
+/**
+ * Reassigns all node revisions by $account to by owned by anonymous (uid 0).
+ *
+ * Replicating functionality of node module, because node code is intended to
+ * be run from a form or otherwise batched.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The user.
+ */
+function _infofinland_user_cancel_reassign_nodes_to_anonymous(UserInterface $account): void {
+
+    $database = \Drupal::database();
+    $tables = [
+      'node_field_data' => 'uid',
+      'node_field_revision' => 'uid',
+      'node_revision' => 'revision_uid',
+    ];
+
+    $user_id = $account->id();
+    foreach ($tables as $table => $uid_field) {
+      $matches = $database->select($table)
+        ->condition($uid_field, $user_id)
+        ->countQuery()
+        ->execute()
+        ->fetchField();
+
+      if ((int) $matches < 1) {
+        continue;
+      }
+
+      $database->update($table)
+        ->fields([$uid_field => 0])
+        ->condition($uid_field, $user_id)
+        ->execute();
+      \Drupal::logger('infofinland_user_cancel')->notice(t('Set @count rows from @table to 0 from @uid',
+        [
+          '@count' => $matches,
+          '@table' => $table,
+          '@uid' => $user_id,
+        ]
+      ));
+    }
+
+  }

--- a/public/modules/custom/infofinland_user_cancel/tests/src/Functional/UserCancelNodeRevisionsTest.php
+++ b/public/modules/custom/infofinland_user_cancel/tests/src/Functional/UserCancelNodeRevisionsTest.php
@@ -1,0 +1,146 @@
+<?php
+
+namespace Drupal\Tests\infofinland_user_cancel\Functional;
+
+use Drupal\Core\Database\Database;
+use Drupal\Tests\BrowserTestBase;
+
+/**
+ * Tests for anonymising node revisions when canceling users.
+ */
+class UserCancelNodeRevisionsTest extends BrowserTestBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  protected $defaultTheme = 'stark';
+
+  /**
+   * An array of node revisions.
+   *
+   * @var \Drupal\node\NodeInterface[]
+   */
+  protected $nodes;
+
+  /**
+   * User entity.
+   *
+   * @var \Drupal\user\Entity\User
+   */
+  protected $user;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected static $modules = [
+    'node',
+    'infofinland_user_cancel',
+  ];
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+
+    // Create Basic page node type.
+    $this->drupalCreateContentType([
+      'type' => 'page',
+      'name' => 'Basic page',
+      'display_submitted' => FALSE,
+    ]);
+
+    // Create and log in user.
+    $user = $this->drupalCreateUser(
+      [
+        'view page revisions',
+        'revert page revisions',
+        'edit any page content',
+      ]
+    );
+
+    $this->drupalLogin($user);
+
+    // Create initial node.
+    $node = $this->drupalCreateNode();
+
+    $nodes = [];
+    $nodes[] = clone $node;
+
+    // Create three revisions for a total of 4 including original.
+    $revision_count = 3;
+    for ($i = 0; $i < $revision_count; $i++) {
+      // Create revision with a random title and body and update variables.
+      $node->title = $this->randomMachineName();
+      $node->setNewRevision();
+      $node->save();
+      $nodes[] = clone $node;
+    }
+
+    $this->user = $user;
+    $this->nodes = $nodes;
+  }
+
+  /**
+   * Check that revisions exist.
+   */
+  public function testRevisionsExist() {
+    $node = reset($this->nodes);
+
+    $connection = Database::getConnection();
+    $revision_count = $connection->select('node_revision')
+      ->condition('revision_uid', $this->user->id())
+      ->condition('nid', $node->id())
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+
+    $this->assertEquals(4, (int) $revision_count, 'Amount of revisions does not match.');
+  }
+
+  /**
+   * Check that revision anonymisation function works.
+   */
+  public function testRevisionAnonymisation() {
+    $node = reset($this->nodes);
+
+    // Run function for test user.
+    _infofinland_user_cancel_reassign_nodes_to_anonymous($this->user);
+
+    // Test that revisions for this user were anonymized correctly.
+    $connection = Database::getConnection();
+    $revision_count = $connection->select('node_revision')
+      ->condition('revision_uid', $this->user->id())
+      ->condition('nid', $node->id())
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(0, (int) $revision_count, 'Found revisions after running anonymisation function.');
+
+    // Test that the revisions were correctly assigned to uid 0.
+    $anon_revision_count = $connection->select('node_revision')
+      ->condition('revision_uid', 0)
+      ->condition('nid', $node->id())
+      ->countQuery()
+      ->execute()
+      ->fetchField();
+    $this->assertEquals(4, (int) $anon_revision_count, 'Amount of anonymized revisions does not match');
+  }
+
+  /**
+   * Test that infofinland_user_cancel hook is invoked before node module.
+   */
+  public function testUserCancelHookOrder() {
+    $moduleHandler = \Drupal::moduleHandler();
+    $module_found = FALSE;
+    $moduleHandler->invokeAllWith('user_cancel', function (callable $hook, string $module) use (&$module_found) {
+      if ($module === 'infofinland_user_cancel') {
+        $module_found = TRUE;
+      }
+      if ($module === 'node') {
+        $this->assertTrue($module_found, 'Node user_cancel hook found before infofinland_user_cancel hook.');
+      }
+    });
+  }
+
+}


### PR DESCRIPTION
# [UHF-9770](https://helsinkisolutionoffice.atlassian.net/browse/UHF-9770)

## What was done
Adds a new module that invokes the `user_cancel` hook to reassign node revisions to anonymous with a simpler db queries. This bypasses the `node_mass_update` calls which seem to cause issues when there are too many revisions.

Relies on the module being invoked the `node` module. Currently works because this is before in alphabetical order, but might need to use module weight if the order changes in the future.

## Replicate the issue
* Use the `dev` branch and make sure it is up-to-date: `git checkout dev`
* Run `make fresh`
* Try canceling UID 82: https://drupal-infofinland.docker.so/fi/user/82/edit
  * This should take a very long time (about 2 hours). Check that the process is going slowly by waiting for a few minutes and cancel the process

## How to install
* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-9770-account-canceling-fix`
  * `make fresh`
* Run `make drush-cr`
* Check that UID 82 exists: https://drupal-infofinland.docker.so/fi/user/82/edit

## How to test
* Create a new user with content editing rights: https://drupal-infofinland.docker.so/fi/admin/people/create
  * Add a few nodes with that user and edit them to create revisions
  * [ ] Cancel the user account (select the default options). The user account should be deleted without issues and the nodes (and revisions) should now be anonymous
  * [ ] Check the recent log messages: https://drupal-infofinland.docker.so/en/admin/reports/dblog?type%5B%5D=infofinland_user_cancel . There should be information on how many database rows were affected.
* Try canceling UID 82: https://drupal-infofinland.docker.so/fi/user/82/edit
  * [ ] The operation should complete in seconds without errors
  * [ ] Check the recent log messages, you should see information about reassigned nodes and revision again
* [ ] Check that code follows our standards
* [ ] Make sure the tests run with `vendor/bin/phpunit -c /app/phpunit.xml.dist public/modules/custom/infofinland_user_cancel`


[UHF-9770]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-9770?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ