### PR TITLE
UHF-X D10 fixes

### DIFF
--- a/public/sites/default/settings.php
+++ b/public/sites/default/settings.php
@@ -383,3 +383,9 @@ if (empty($settings['deployment_identifier'])) {
   $settings['deployment_identifier'] = filemtime(__DIR__ . '/../../../composer.lock');
 }
 
+// Environment indicator hack, see the file for more info
+$env_indicator_settings = dirname(__FILE__) . '/env.indicator.settings.php';
+if (file_exists($env_indicator_settings)) {
+  require_once $env_indicator_settings;
+}
+

--- a/public/themes/custom/infofinland_admin/src/css/styles.css
+++ b/public/themes/custom/infofinland_admin/src/css/styles.css
@@ -30,3 +30,7 @@ a {
 .language-links .is-active {
   font-weight: 700;
 }
+
+#field-municipality-info-values .form-textarea-wrapper {
+  width: 300px;
+}


### PR DESCRIPTION
## What was done

- Fixed node edit page sidebar overflow
- Missing environment indicator configurations added to settings.php

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_node_sidebar_overflow_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test

- Check node edit form sidebar
- Check environment indicator color
