### PR TITLE
Better checks on ckeditor fix, ckeditor header fix

### DIFF
--- a/public/modules/custom/helfi_ckeditor/helfi_ckeditor.module
+++ b/public/modules/custom/helfi_ckeditor/helfi_ckeditor.module
@@ -37,10 +37,30 @@ function helfi_ckeditor_ckeditor5_plugin_info_alter(array &$plugin_definitions):
 /**
  * Implements hook_js_settings_alter().
  */
-function helfi_ckeditor_js_settings_alter(array &$settings, AttachedAssetsInterface $assets) {
-  // Ckeditor uses UI language to decide whether to use LTR or RTL direction on editor.
-  // Overwrite the UI langcode with content langcode to instantiate the ckeditor with correct direction.
-  $content_language = \Drupal::languageManager()->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
-  $settings['editor']['formats']['full_html']['editorSettings']['language']['ui'] = $content_language->getId();
-  $settings['editor']['formats']['simple_html']['editorSettings']['language']['ui'] = $content_language->getId();
+function helfi_ckeditor_js_settings_alter(array &$settings) {
+  // UI language is used to decide the content direction on editor.
+  // Therefore, we must override the ui language with content language.
+  // Also, header must be turned around to ensure correct alignment.
+  if (!isset($settings['editor']['formats'])) {
+    return;
+  }
+
+  $language_manager = \Drupal::languageManager();
+  $content_language = $language_manager
+    ->getCurrentLanguage(LanguageInterface::TYPE_CONTENT);
+
+  $ui_language_direction = $language_manager
+    ->getCurrentLanguage(LanguageInterface::TYPE_INTERFACE)
+    ->getDirection();
+
+  $language_id = $content_language->getId();
+
+  foreach ($settings['editor']['formats'] as $name => $array) {
+    $settings['editor']['formats'][$name]['editorSettings']['language']['ui'] = $language_id;
+    if ($ui_language_direction === 'ltr') {
+      $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items'] = array_reverse(
+        $settings['editor']['formats'][$name]['editorSettings']['toolbar']['items']
+      );
+    }
+  }
 }


### PR DESCRIPTION
## What was done

Better checks
Ckeditor alignment fix

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X_ckeditor_header_fix`
  * `make fresh`
* Run `make drush-cr`

## How to test

- Go edit any content page in arabic.
- CKeditor content should be aligned RTL
- Header should be aligned LTR


