### PR TITLE
UHF-X: Remove expired oauth2 tokens

### DIFF
--- a/conf/cmi/config_ignore.settings.yml
+++ b/conf/cmi/config_ignore.settings.yml
@@ -5,5 +5,4 @@ ignored_config_entities:
   - elasticsearch_connector.cluster.infofinland
   - 'next.next_site.*'
   - next.settings
-  - simple_oauth.settings
   - update.settings

--- a/conf/cmi/simple_oauth.settings.yml
+++ b/conf/cmi/simple_oauth.settings.yml
@@ -3,7 +3,7 @@ _core:
 access_token_expiration: 300
 authorization_code_expiration: 300
 refresh_token_expiration: 1209600
-token_cron_batch_size: 0
+token_cron_batch_size: 100
 public_key: /var/www/html/keys/public.key
 private_key: /var/www/html/keys/private.key
 remember_clients: true

--- a/conf/cmi/ultimate_cron.job.simple_oauth_cron.yml
+++ b/conf/cmi/ultimate_cron.job.simple_oauth_cron.yml
@@ -13,7 +13,7 @@ scheduler:
   id: simple
   configuration:
     rules:
-      - '0+@ 0 * * *'
+      - '0+@ */6 * * *'
 launcher:
   id: serial
   configuration:

--- a/public/modules/custom/infofinland_common/infofinland_common.install
+++ b/public/modules/custom/infofinland_common/infofinland_common.install
@@ -86,20 +86,25 @@ function infofinland_common_update_9002(): void {
 }
 
 function infofinland_common_update_9003(): void {
-  $modules = [
-    'config_replace',
-    'hdbt_component_library',
-    'hdbt_content',
-    'hdbt_hyphenopoly',
-    'node_revision_delete',
-    'infofinland_ckeditor',
-  ];
-
   \Drupal::service('database')->delete('key_value')->condition('name', 'config_replace')->execute();
   \Drupal::service('database')->delete('key_value')->condition('name', 'hdbt_component_library')->execute();
   \Drupal::service('database')->delete('key_value')->condition('name', 'hdbt_content')->execute();
   \Drupal::service('database')->delete('key_value')->condition('name', 'hdbt_hyphenopoly')->execute();
   \Drupal::service('database')->delete('key_value')->condition('name', 'node_revision_delete')->execute();
   \Drupal::service('database')->delete('key_value')->condition('name', 'infofinland_ckeditor')->execute();
+}
 
+/**
+ * Delete expired tokens.
+ *
+ * @see \simple_oauth_cron()
+ * @see \Drupal\simple_oauth\ExpiredCollector
+ */
+function infofinland_common_update_9004(): void {
+  $time = \Drupal::time();
+  $database = \Drupal::database();
+
+  $database->delete('oauth2_token')
+    ->condition('expire', $time->getRequestTime(), '<')
+    ->execute();
 }

--- a/public/sites/default/all.settings.php
+++ b/public/sites/default/all.settings.php
@@ -22,6 +22,9 @@ if (getenv('INFOFINLAND_UI_URL')) {
   $config['next.next_site.infofinland_ui']['preview_secret'] = getenv('DRUPAL_PREVIEW_SECRET');
 }
 
+$config['simple_oauth.settings']['public_key'] = '/var/www/html/keys/public.key';
+$config['simple_oauth.settings']['private_key'] = '/var/www/html/keys/private.key';
+
 // Hardcoded simple_oauth keys for local development.
 if (getenv('APP_ENV') === 'local') {
   $config['simple_oauth.settings']['public_key'] = '/app/conf/local-keys/public.key';


### PR DESCRIPTION
## What was done
<!-- Describe what was done -->

* Fix out of memory issues when Drupal tries to handle oauth tokens.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-X-out-of-memory-error`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [x] Try to delete nextjs user.
* [x] Check that code follows our standards
