### PR TITLE
UHF-10175 language switcher bug

### DIFF
--- a/public/modules/custom/infofinland_admin_tools/infofinland_admin_tools.module
+++ b/public/modules/custom/infofinland_admin_tools/infofinland_admin_tools.module
@@ -22,7 +22,7 @@ function infofinland_admin_tools_toolbar_alter(&$items) {
  *  Implements hook_language_switch_links_alter().
  */
 function infofinland_admin_tools_language_switch_links_alter(array &$links) {
-  $route_match = \Drupal::routeMatch();
+  $route_match = Drupal::routeMatch();
   $entity = FALSE;
 
   // Determine if the current route represents an entity.
@@ -31,9 +31,15 @@ function infofinland_admin_tools_language_switch_links_alter(array &$links) {
     ($parameters = $route->getOption('parameters'))
   ) {
     foreach ($parameters as $name => $options) {
-      if (isset($options['type']) && strpos($options['type'], 'entity:') === 0) {
+      if (
+        isset($options['type']) &&
+        str_starts_with($options['type'], 'entity:')
+      ) {
         $parameter = $route_match->getParameter($name);
-        if ($parameter instanceof ContentEntityInterface && $parameter->hasLinkTemplate('canonical')) {
+        if (
+          $parameter instanceof ContentEntityInterface &&
+          $parameter->hasLinkTemplate('canonical')
+        ) {
           $entity = $parameter;
           break;
         }
@@ -41,20 +47,31 @@ function infofinland_admin_tools_language_switch_links_alter(array &$links) {
     }
   }
 
+  $language_resolver = \Drupal::service('helfi_api_base.default_language_resolver');
+  $primary_languages = $language_resolver->getDefaultLanguages();
+
   // Compare the links with current entity and check for possible translations.
   foreach ($links as $lang_code => &$link) {
     $link['#abbreviation'] = $lang_code;
 
-    if ($entity && $entity instanceof ContentEntityInterface) {
-      if (
-        !$entity->hasTranslation($lang_code) ||
-        (
-          method_exists($entity->getTranslation($lang_code), 'isPublished') &&
-          !$entity->getTranslation($lang_code)->isPublished()
-        )
-      ) {
-        $link['#untranslated'] = TRUE;
-      }
+    if (in_array($lang_code, $primary_languages)) {
+      $link['#primary_language'] = TRUE;
+    }
+
+    if (!$entity instanceof ContentEntityInterface) {
+      continue;
+    }
+
+    if (!$entity->hasTranslation($lang_code)) {
+      $link['#untranslated'] = TRUE;
+      continue;
+    }
+
+    if (
+      method_exists($entity->getTranslation($lang_code), 'isPublished') &&
+      !$entity->getTranslation($lang_code)->isPublished()
+    ) {
+      $link['#untranslated'] = TRUE;
     }
   }
 }

--- a/public/modules/custom/infofinland_admin_tools/infofinland_admin_tools.module
+++ b/public/modules/custom/infofinland_admin_tools/infofinland_admin_tools.module
@@ -50,6 +50,21 @@ function infofinland_admin_tools_language_switch_links_alter(array &$links) {
   $language_resolver = \Drupal::service('helfi_api_base.default_language_resolver');
   $primary_languages = $language_resolver->getDefaultLanguages();
 
+  // UHF-10175 routematch returns old revision in some cases
+  if (
+    $entity instanceof ContentEntityInterface &&
+    $entity->getEntityType()->isRevisionable() &&
+    !$entity->isLatestRevision()
+  ) {
+    try {
+      $entity_storage = \Drupal::entityTypeManager()->getStorage($entity->getEntityTypeId());
+      $entity = $entity_storage->load($entity->id());
+    }
+    catch(\Exception $e) {
+      // Do nothing.
+    }
+  }
+
   // Compare the links with current entity and check for possible translations.
   foreach ($links as $lang_code => &$link) {
     $link['#abbreviation'] = $lang_code;


### PR DESCRIPTION
# [UHF-10175](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10175)
Language switcher on node edit shows wrong languages in specific scenario.

## What was done
Use latest revision of node when altering language switcher

## How to reproduce
- Setup the site
- Log in as admin
- Go edit node 39579
- Select finnish as language
- Check the language switcher active links
  - Should not represent the actual node translations 
- Select any other language (Russian for example)
- Language switcher active links should change
  - Should now show the language swithcer active links correctly 

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10175`
  * `make fresh`
* Run `make drush-cr`

## How to test
- Log in as admin
- Go edit node 39579
- All language switcher links should be active on finnish
- Language switcher should show same result for every translation.  



* [x] Check that this feature works
* [x] Check that code follows our standards


[UHF-10175]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ