### PR TITLE
UHF-10062: config fixes

### DIFF
--- a/conf/cmi/language/ar/webform.webform.contact.yml
+++ b/conf/cmi/language/ar/webform.webform.contact.yml
@@ -1,1 +1,47 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/es/webform.webform.contact.yml
+++ b/conf/cmi/language/es/webform.webform.contact.yml
@@ -1,1 +1,49 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    label: 'Email confirmation'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/et/webform.webform.contact.yml
+++ b/conf/cmi/language/et/webform.webform.contact.yml
@@ -1,1 +1,48 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/fa/webform.webform.contact.yml
+++ b/conf/cmi/language/fa/webform.webform.contact.yml
@@ -1,1 +1,48 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/fi/webform.webform.contact.yml
+++ b/conf/cmi/language/fi/webform.webform.contact.yml
@@ -1,1 +1,48 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/fr/webform.webform.contact.yml
+++ b/conf/cmi/language/fr/webform.webform.contact.yml
@@ -1,1 +1,51 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    label: 'Email confirmation'
+    settings:
+      from_name: _default
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      from_name: '[webform_submission:values:name:raw]'
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/ru/webform.webform.contact.yml
+++ b/conf/cmi/language/ru/webform.webform.contact.yml
@@ -1,1 +1,49 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    label: 'Email confirmation'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/sv/webform.webform.contact.yml
+++ b/conf/cmi/language/sv/webform.webform.contact.yml
@@ -1,1 +1,49 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    label: 'Email confirmation'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/tr/webform.webform.contact.yml
+++ b/conf/cmi/language/tr/webform.webform.contact.yml
@@ -1,1 +1,48 @@
 title: Contact
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+settings:
+  confirmation_message: 'Your message has been sent.'
+handlers:
+  email_confirmation:
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+  email_notification:
+    label: 'Email notification'
+    settings:
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/language/uk/webform.webform.contact.yml
+++ b/conf/cmi/language/uk/webform.webform.contact.yml
@@ -1,9 +1,52 @@
 title: Контакт
 description: 'Проста електронна контактна веб-форма.'
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
 settings:
   confirmation_message: 'Ваше повідомлення було надіслано.'
 handlers:
   email_confirmation:
     label: 'Підтвердження поштою'
+    settings:
+      from_name: _default
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
   email_notification:
     label: 'Електронне сповіщення'
+    settings:
+      from_name: '[webform_submission:values:name:raw]'
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'

--- a/conf/cmi/webform.webform.contact.yml
+++ b/conf/cmi/webform.webform.contact.yml
@@ -14,7 +14,7 @@ open: null
 close: null
 uid: null
 template: false
-archive: false
+archive: true
 id: contact
 title: Contact
 description: 'Basic email contact webform.'

--- a/conf/cmi/webform.webform.infofinland_contact.yml
+++ b/conf/cmi/webform.webform.infofinland_contact.yml
@@ -1,0 +1,325 @@
+uuid: ab2de020-512a-487f-86d1-43b16fa022cb
+langcode: en
+status: open
+dependencies:
+  module:
+    - infofinland_common
+  enforced:
+    module:
+      - webform
+_core:
+  default_config_hash: CJr5U2B4if_Ff1SZfnNp_csPKwXIynmbUlBC-SmSOAE
+weight: 0
+open: null
+close: null
+uid: null
+template: false
+archive: false
+id: infofinland_contact
+title: 'Infofinland Contact'
+description: 'Basic email contact webform.'
+categories: {  }
+elements: |-
+  name:
+    '#title': 'Your Name'
+    '#type': textfield
+    '#required': true
+    '#default_value': '[current-user:display-name]'
+  sender_email:
+    '#title': 'Sender Email'
+    '#type': email
+    '#required': true
+    '#default_value': '[current-user:mail]'
+  feedback_email:
+    '#title': 'Feedback Email'
+    '#type': email
+    '#required': true
+    '#default_value': infofinland.palaute@hel.fi
+    '#access': false
+  page:
+    '#title': Page
+    '#type': textfield
+    '#required': true
+  subject:
+    '#title': Subject
+    '#type': textfield
+    '#required': true
+    '#test': 'Test email'
+  message:
+    '#title': Message
+    '#type': textarea
+    '#required': true
+    '#test': 'Test email'
+  actions:
+    '#type': webform_actions
+    '#title': 'Submit button(s)'
+    '#submit__label': 'Send message'
+css: ''
+javascript: ''
+settings:
+  ajax: false
+  ajax_scroll_top: form
+  ajax_progress_type: ''
+  ajax_effect: ''
+  ajax_speed: null
+  page: true
+  page_submit_path: ''
+  page_confirm_path: ''
+  page_theme_name: ''
+  form_title: source_entity_webform
+  form_submit_once: false
+  form_open_message: ''
+  form_close_message: ''
+  form_exception_message: ''
+  form_previous_submissions: true
+  form_confidential: false
+  form_confidential_message: ''
+  form_disable_remote_addr: true
+  form_convert_anonymous: false
+  form_prepopulate: false
+  form_prepopulate_source_entity: false
+  form_prepopulate_source_entity_required: false
+  form_prepopulate_source_entity_type: ''
+  form_unsaved: false
+  form_disable_back: false
+  form_submit_back: false
+  form_disable_autocomplete: false
+  form_novalidate: false
+  form_disable_inline_errors: false
+  form_required: false
+  form_autofocus: false
+  form_details_toggle: false
+  form_reset: false
+  form_access_denied: default
+  form_access_denied_title: ''
+  form_access_denied_message: ''
+  form_access_denied_attributes: {  }
+  form_file_limit: ''
+  form_attributes: {  }
+  form_method: ''
+  form_action: ''
+  share: false
+  share_node: false
+  share_theme_name: ''
+  share_title: true
+  share_page_body_attributes: {  }
+  submission_label: ''
+  submission_exception_message: ''
+  submission_locked_message: ''
+  submission_log: false
+  submission_excluded_elements: {  }
+  submission_exclude_empty: false
+  submission_exclude_empty_checkbox: false
+  submission_views: {  }
+  submission_views_replace: {  }
+  submission_user_columns: {  }
+  submission_user_duplicate: false
+  submission_access_denied: default
+  submission_access_denied_title: ''
+  submission_access_denied_message: ''
+  submission_access_denied_attributes: {  }
+  previous_submission_message: ''
+  previous_submissions_message: ''
+  autofill: false
+  autofill_message: ''
+  autofill_excluded_elements: {  }
+  wizard_progress_bar: true
+  wizard_progress_pages: false
+  wizard_progress_percentage: false
+  wizard_progress_link: false
+  wizard_progress_states: false
+  wizard_start_label: ''
+  wizard_preview_link: false
+  wizard_confirmation: true
+  wizard_confirmation_label: ''
+  wizard_auto_forward: true
+  wizard_auto_forward_hide_next_button: false
+  wizard_keyboard: true
+  wizard_track: ''
+  wizard_prev_button_label: ''
+  wizard_next_button_label: ''
+  wizard_toggle: false
+  wizard_toggle_show_label: ''
+  wizard_toggle_hide_label: ''
+  wizard_page_type: container
+  wizard_page_title_tag: h2
+  preview: 0
+  preview_label: ''
+  preview_title: ''
+  preview_message: ''
+  preview_attributes: {  }
+  preview_excluded_elements: {  }
+  preview_exclude_empty: true
+  preview_exclude_empty_checkbox: false
+  draft: none
+  draft_multiple: false
+  draft_auto_save: false
+  draft_saved_message: ''
+  draft_loaded_message: ''
+  draft_pending_single_message: ''
+  draft_pending_multiple_message: ''
+  confirmation_type: url_message
+  confirmation_url: '<front>'
+  confirmation_title: ''
+  confirmation_message: 'Your message has been sent.'
+  confirmation_attributes: {  }
+  confirmation_back: true
+  confirmation_back_label: ''
+  confirmation_back_attributes: {  }
+  confirmation_exclude_query: false
+  confirmation_exclude_token: false
+  confirmation_update: false
+  limit_total: null
+  limit_total_interval: null
+  limit_total_message: ''
+  limit_total_unique: false
+  limit_user: null
+  limit_user_interval: null
+  limit_user_message: ''
+  limit_user_unique: false
+  entity_limit_total: null
+  entity_limit_total_interval: null
+  entity_limit_user: null
+  entity_limit_user_interval: null
+  purge: completed
+  purge_days: 180
+  results_disabled: false
+  results_disabled_ignore: false
+  results_customize: false
+  token_view: false
+  token_update: false
+  token_delete: false
+  serial_disabled: false
+access:
+  create:
+    roles:
+      - anonymous
+      - authenticated
+    users: {  }
+    permissions: {  }
+  view_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  purge_any:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  view_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  update_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  delete_own:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  administer:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  test:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+  configuration:
+    roles: {  }
+    users: {  }
+    permissions: {  }
+handlers:
+  email_confirmation:
+    id: email
+    handler_id: email_confirmation
+    label: 'Email confirmation'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: -49
+    settings:
+      states:
+        - completed
+      to_mail: '[webform_submission:values:feedback_email:raw]'
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: _default
+      from_options: {  }
+      from_name: _default
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: 'Palaute Infofinland sivustolta'
+      body: "<p>Palaute Infofinland sivulta:&nbsp;[webform_submission:values:page]<br />\r\n<br />\r\nL&auml;hett&auml;j&auml;: [webform_submission:values:name]<br />\r\nEmail: [webform_submission:values:sender_email]&nbsp;&nbsp;<br />\r\nAihe: [webform_submission:values:subject]&nbsp;<br />\r\nViesti: [webform_submission:values:message]&nbsp;</p>"
+      excluded_elements: {  }
+      ignore_access: false
+      exclude_empty: true
+      exclude_empty_checkbox: false
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  email_notification:
+    id: email
+    handler_id: email_notification
+    label: 'Email notification'
+    notes: ''
+    status: false
+    conditions: {  }
+    weight: -48
+    settings:
+      states:
+        - completed
+      to_mail: _default
+      to_options: {  }
+      bcc_mail: ''
+      bcc_options: {  }
+      cc_mail: ''
+      cc_options: {  }
+      from_mail: '[webform_submission:values:email:raw]'
+      from_options: {  }
+      from_name: '[webform_submission:values:name:raw]'
+      reply_to: ''
+      return_path: ''
+      sender_mail: ''
+      sender_name: ''
+      subject: '[webform_submission:values:subject:raw]'
+      body: '[webform_submission:values:message:value]'
+      excluded_elements: {  }
+      ignore_access: false
+      exclude_empty: true
+      exclude_empty_checkbox: false
+      exclude_attachments: false
+      html: true
+      attachments: false
+      twig: false
+      theme_name: ''
+      parameters: {  }
+      debug: false
+  feedback_email:
+    id: infofinland_feedback_email
+    handler_id: feedback_email
+    label: 'Feedback email'
+    notes: ''
+    status: true
+    conditions: {  }
+    weight: -50
+    settings:
+      default_email: infofinland.palaute@hel.fi
+variants: {  }

--- a/public/modules/custom/infofinland_common/infofinland_common.module
+++ b/public/modules/custom/infofinland_common/infofinland_common.module
@@ -118,11 +118,14 @@ function infofinland_common_preprocess_status_messages(&$variables) {
   if (isset($variables['message_list']['warning'])) {
     $status_messages = $variables['message_list']['warning'];
     foreach($status_messages as $delta => $message) {
-      if (strpos((string) $message, 'The current translation is not in sync with the Finnish one') !== FALSE) {
+      if (!is_string($message) && !$message instanceof Stringable) {
+        continue;
+      }
+
+      if (str_contains((string) $message, 'The current translation is not in sync with the Finnish one')) {
         $variables['attributes']['class'] = 'custom-messages--warning';
       }
     }
-
   }
 }
 


### PR DESCRIPTION
# [UHF-10062](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10062)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

Our automatic updates want to add translations to default contact form since it is included in webform/config/install. The translations override important webform handler settings.

See: 1b366e5ae0237455420d92d1c336126d6449b95e.
    
This patch copies `webform.webform.config` to `webform.webform.infofinland_config` so we can manage translations ourselves.

* Prevent automatic updates from overriding contact form handlers. 
  * Add new webform `infofinland_contact`
  * Archive webform `contact`

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10062-config-fixes`
  * `make up shell`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Download latests artifact, simulate update config workflow with `$(drush sql:connect) < latest.sql; drush cim -y; drush cr; drush locale:check; drush locale:update; drush cex -y`. Config changes should look ok.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation

## Translations
<!-- The checkbox below needs to be checked like this: `[x]` (or click when not in edit mode). Not needed if the translations were not affected. -->

* [x] Translations have been added to .po -files and included in this PR

## Other PRs
<!-- For example an related PR in another repository -->

* Link to other PR


[UHF-10062]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ