### PR TITLE
UHF-10603: old patches broke sitemap SSR

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -154,7 +154,7 @@
                 "Get same results on different request": "https://www.drupal.org/files/issues/2024-08-06/subrequests-3049395-change-request-type.patch"
             },
             "drupal/decoupled_router": {
-                "Fixing redirect multilanguage 404": "https://www.drupal.org/files/issues/2024-08-05/decouple_router-3111456-resolve-language-issue-63--get-translation-re-rolled-and-good-redirect.patch"
+                "Fixing redirect multilanguage 404 (https://drupal.org/i/3111456)": "https://www.drupal.org/files/issues/2024-08-05/decouple_router-3111456-resolve-language-issue-63--get-translation-re-rolled-and-good-redirect.patch"
             },
             "drupal/redirect": {
                 "Validation issue on adding url redirect (https://drupal.org/i/3057250)": "https://www.drupal.org/files/issues/2024-08-11/redirect--2024-08-11--3057250-79.patch",

--- a/composer.json
+++ b/composer.json
@@ -150,8 +150,11 @@
             "drupal/publication_date": {
                 "[#UHF-7721] Fixed node preview when publication date is not set. (https://drupal.org/i/3074373)": "https://www.drupal.org/files/issues/2022-12-20/publication_date_is_required_for_completing_the_form-3074373-11.patch"
             },
+            "drupal/subrequests": {
+                "Get same results on different request": "https://www.drupal.org/files/issues/2024-08-06/subrequests-3049395-change-request-type.patch"
+            },
             "drupal/decoupled_router": {
-                "Fixing redirect multilanguage 404 (https://drupal.org/i/3111456)": "https://www.drupal.org/files/issues/2022-12-01/decouple_router-3111456-resolve-language-issue-58--get-translation.patch"
+                "Fixing redirect multilanguage 404": "https://www.drupal.org/files/issues/2024-08-05/decouple_router-3111456-resolve-language-issue-63--get-translation-re-rolled-and-good-redirect.patch"
             },
             "drupal/redirect": {
                 "Validation issue on adding url redirect (https://drupal.org/i/3057250)": "https://www.drupal.org/files/issues/2024-08-11/redirect--2024-08-11--3057250-79.patch",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "524314c70a5350679be6f90501d14673",
+    "content-hash": "5eab3e81895dbab08aa5de957a72f418",
     "packages": [
         {
             "name": "asm89/stack-cors",
@@ -2400,29 +2400,30 @@
         },
         {
             "name": "drupal/decoupled_router",
-            "version": "2.0.4",
+            "version": "2.0.5",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/decoupled_router.git",
-                "reference": "2.0.4"
+                "reference": "2.0.5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/decoupled_router-2.0.4.zip",
-                "reference": "2.0.4",
-                "shasum": "8dacb4460c93a3fa9b034516a7e1caaf254be76b"
+                "url": "https://ftp.drupal.org/files/projects/decoupled_router-2.0.5.zip",
+                "reference": "2.0.5",
+                "shasum": "0899f6331358aac1476e72fc60a8f03d5654c654"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9 || ^10"
+                "drupal/core": "^9.5 || ^10 || ^11",
+                "php": ">=8.1"
             },
             "require-dev": {
-                "drupal/redirect": "^1.8"
+                "drupal/redirect": "dev-1.x"
             },
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.4",
-                    "datestamp": "1669803945",
+                    "version": "2.0.5",
+                    "datestamp": "1720638599",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"


### PR DESCRIPTION
# [UHF-0000](https://helsinkisolutionoffice.atlassian.net/browse/UHF-0000)

## What was done
Upgraded the patches

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10603_fix_patches`
  * `make fresh`
* Run `make drush-cr`
* Setup frontend

## How to test
run yarn 
run yarn build
build process should finish without completely dying (Done in xx.yy s.)
/fi/sitemap page should load

