### PR TITLE
UHF-10654: Apply patch to fix yoast errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -125,6 +125,9 @@
             },
             "drupal/next": {
                 "Fix 500 error when submitting contact form and DB saving has been disabled, to be removed when drupal/next:2.0 is updated": "./patches/webforms.patch"
+            },
+            "drupal/yoast_seo": {
+                "Fix \"Uncaught DOMException: Failed to execute 'remove' on 'DOMTokenList'\" (https://www.drupal.org/project/yoast_seo/issues/3394487)": "https://www.drupal.org/files/issues/2023-11-03/3394487-failed-to-execute-remove-on-domtokenlist.patch"
             }
         },
         "installer-types": ["npm-asset"],


### PR DESCRIPTION
# [UHF-10654](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10654)
Yoast SEO plugin was throwing error at page load, causinge aggregated JS file execution failure.

## What was done
Bug we were experiencing is a known one. Applied patch to fix it.

## How to install

* If you want to see the bug in action, first do this:
  *  `git checkout origin/dev`
  * `make fresh` if necessary
  * Run `make drush-cr`

Now, while you're in dev branch, go to: https://drupal-infofinland.docker.so/en/node/add/page. Open the console and you should see an error:
```
Uncaught DOMException: DOMTokenList.remove: The token can not contain whitespace.
```

To apply the fix:
* Make sure your instance is up and running on correct branch.
  * `git checkout origin/UHF-10654-fix-yoast-error`
  * `make shell` into the container
  * Run `composer install`. You should see the patch getting applied
  * Run `make drush-cr`

... OR just checkout to the branch and run `make fresh`

## How to test

Without aggregation;
* Go to: https://drupal-infofinland.docker.so/en/node/add/page
* You should no longer see the exception being thrown (note that at least for me, gin still does throw one. This is not the exception you are looking for)

With aggregation:
* Go to your `local.settings.php`

```
$config['system.performance']['css']['preprocess'] = FALSE;
$config['system.performance']['js']['preprocess'] = FALSE;
```
* Comment out ☝️ lines
* Run `make drush-cr`
* Check https://drupal-infofinland.docker.so/en/node/add/page
* The error should be gone and page should be editable without issue

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation


[UHF-10654]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10654?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ