### PR TITLE
UHF-10199: Enable underline-tag for full html text format

### DIFF
--- a/conf/cmi/editor.editor.full_html.yml
+++ b/conf/cmi/editor.editor.full_html.yml
@@ -14,6 +14,7 @@ settings:
       - bold
       - italic
       - strikethrough
+      - underline
       - superscript
       - subscript
       - removeFormat

--- a/conf/cmi/filter.format.full_html.yml
+++ b/conf/cmi/filter.format.full_html.yml
@@ -40,7 +40,7 @@ filters:
     status: true
     weight: -50
     settings:
-      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <figure tabindex> <figcaption> <strong> <em> <s> <sub> <sup> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <span dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <figure tabindex> <figcaption> <strong> <em> <u> <s> <sub> <sup> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <span dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
       filter_html_help: true
       filter_html_nofollow: false
   filter_html_escape:


### PR DESCRIPTION
# [UHF-10199](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10199)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Permit the underline html tag for CKEditor full html format.
* Add the button to underline or remove underline from text in the editor.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10199`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that you are now able to preserve underlined text when pasting it from Word to the text editor in InfoFinland.
* [ ] Check that code follows our standards.

## Continuous documentation
<!-- One of the checkboxes below needs to be checked like this: `[x]` (or click when not in edit mode) -->

* [ ] This feature has been documented/the documentation has been updated
* [x] This change doesn't require updates to the documentation