### PR TITLE
UHF-10742 paragraph copier

### DIFF
--- a/docker/openshift/crons/base.sh
+++ b/docker/openshift/crons/base.sh
@@ -20,6 +20,7 @@ echo "Starting cron: $(date)"
 #exec "/crons/migrate-tpr.sh" &
 # Uncomment this to enable Varnish purge cron
 exec "/crons/purge-queue.sh" &
+exec "/cron/purge-copied-paragraphs.sh" &
 # Uncomment this to enable automatic translation updates.
 # exec "/crons/update-translations.sh" &
 

--- a/docker/openshift/crons/purge-copied-paragraphs.sh
+++ b/docker/openshift/crons/purge-copied-paragraphs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+while true
+do
+  echo "Copying paragraphs: $(date +'%Y-%m-%dT%H:%M:%S%:z')\n"
+  drush drush:queue-run paragraph_copy_worker --time-limit=60 --lease-time=60 --items-limit=3
+  sleep 60
+done

--- a/docker/openshift/crons/purge-copied-paragraphs.sh
+++ b/docker/openshift/crons/purge-copied-paragraphs.sh
@@ -3,6 +3,6 @@
 while true
 do
   echo "Copying paragraphs: $(date +'%Y-%m-%dT%H:%M:%S%:z')\n"
-  drush drush:queue-run paragraph_copy_worker --time-limit=60 --lease-time=60 --items-limit=3
+  drush queue-run paragraph_copy_worker --time-limit=60 --lease-time=60 --items-limit=3
   sleep 60
 done

--- a/public/modules/custom/infofinland_common/infofinland_common.module
+++ b/public/modules/custom/infofinland_common/infofinland_common.module
@@ -446,6 +446,12 @@ function _infofinland_common_add_paragraphs_to_node_translations(EntityInterface
   $queue_factory = \Drupal::service('queue');
   $queue_factory->get('paragraph_copy_worker')
     ->createItem($item_to_queue);
+
+  $message = \Drupal::translation()
+    ->translate(
+      'Paragraphs will be copied to other translations in few moments.'
+    );
+  \Drupal::messenger()->addMessage($message);
 }
 
 /**

--- a/public/modules/custom/infofinland_common/infofinland_common.module
+++ b/public/modules/custom/infofinland_common/infofinland_common.module
@@ -10,19 +10,16 @@ declare(strict_types=1);
 use Drupal\Core\Database\Query\AlterableInterface;
 use Drupal\Core\Entity\EntityForm;
 use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Language\LanguageInterface;
 use Drupal\Core\Url;
 use Drupal\editor\Entity\Editor;
 use Drupal\media\Entity\Media;
 use Drupal\node\Entity\Node;
+use Drupal\node\NodeInterface;
 use Drupal\paragraphs\Entity\Paragraph;
-use Drupal\paragraphs\ParagraphInterface;
 use Drupal\path_alias\PathAliasInterface;
 use Drupal\user\Entity\User;
-use Drupal\webform\Plugin\WebformHandlerInterface;
-use Drupal\webform\WebformSubmissionInterface;
 
 /**
  * Implements hook_cron().
@@ -405,9 +402,15 @@ function infofinland_common_node_presave(Node $entity) {
 
 /**
  * Custom function for adding paragraphs from finnish page node to translations.
+ *
+ * #UHF-10742: This feature caused timeout and is moved to queue plugin.
  */
-function _infofinland_common_add_paragraphs_to_node_translations(Node $entity): void {
-  if ($entity->langcode->value !== 'fi' || is_null($entity->id())) {
+function _infofinland_common_add_paragraphs_to_node_translations(EntityInterface $entity): void {
+  if (
+    !$entity instanceof NodeInterface ||
+    is_null($entity->id()) ||
+    $entity->langcode->value !== 'fi'
+  ) {
     return;
   }
 
@@ -434,58 +437,15 @@ function _infofinland_common_add_paragraphs_to_node_translations(Node $entity): 
     return;
   }
 
-  $entity_type_manager = \Drupal::entityTypeManager();
-  $paragraph_storage = $entity_type_manager->getStorage('paragraph');
-  $translation_languages = $entity->getTranslationLanguages();
+  $item_to_queue = [
+    'nid' => $entity->id(),
+    'data' => json_encode($added_paragraphs)
+  ];
 
-  foreach ($translation_languages as $language) {
-    $lang = $language->getId();
-    if ($lang === 'fi') {
-      continue;
-    }
-
-    $node_translation = $entity->getTranslation($lang);
-    $translated_content = $node_translation->get('field_content')->getValue();
-
-    // Merge added finnish paragraphs to translation.
-    foreach ($added_paragraphs as $added_paragraph) {
-      $paragraph = $paragraph_storage->load($added_paragraph['target']);
-
-      if ($paragraph instanceof ParagraphInterface) {
-        $duplicateParagraph = $paragraph->createDuplicate();
-        $duplicateParagraph->set('langcode', $lang);
-        $duplicateParagraph->save();
-
-        $array = [
-          'target_id' => $duplicateParagraph->id(),
-          'target_revision_id' => $duplicateParagraph->getRevisionId(),
-        ];
-        $field_content_merged = array_merge(
-          array_slice($translated_content, 0, $added_paragraph['delta']),
-          [$array],
-          array_slice($translated_content, $added_paragraph['delta'])
-        );
-      }
-    }
-
-    if (!isset($field_content_merged)) {
-      continue;
-    }
-
-    /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $storage */
-    $storage = \Drupal::entityTypeManager()->getStorage($node_translation->getEntityTypeId());
-    $node_translation = $storage->createRevision($node_translation, $node_translation->isDefaultRevision());
-
-    $node_translation->set('moderation_state', 'draft');
-    $node_translation->field_content = $field_content_merged;
-
-    if ($node_translation instanceof RevisionLogInterface) {
-      $node_translation->setRevisionLogMessage('New content added for finnish page and copied to translations');
-      $current_user = \Drupal::currentUser();
-      $node_translation->setRevisionUserId($current_user->id());
-    }
-    $node_translation->save();
-  }
+  /** @var \Drupal\Core\Queue\QueueFactoryInterface $queue_factory */
+  $queue_factory = \Drupal::service('queue');
+  $queue_factory->get('paragraph_copy_worker')
+    ->createItem($item_to_queue);
 }
 
 /**

--- a/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
+++ b/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
@@ -99,7 +99,9 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
           continue;
         }
 
-        $duplicateParagraph = $added_paragraph->addTranslation($lang);
+        $duplicateParagraph = $added_paragraph->createDuplicate();
+        $duplicateParagraph->set('langcode', $lang);
+        $duplicateParagraph->save();
 
         $paragraph_reference = [
           'target_id' => $duplicateParagraph->id(),

--- a/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
+++ b/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
@@ -58,7 +58,6 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
   /**
    * {@inheritdoc}
    */
-
   public function processItem($data): void {
     if (!isset($data['nid']) || !isset($data['data'])) {
       return;
@@ -94,13 +93,13 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
 
       $translated_paragraphs = $node_translation->get('field_content')->getValue();
 
-      foreach ($added_paragraphs as $added_paragraph) {
-        $new_paragraph = $paragraph_storage->load($added_paragraph['target']);
-        if (!$new_paragraph instanceof ParagraphInterface) {
+      foreach ($added_paragraphs as $added_paragraph_data) {
+        $added_paragraph = $paragraph_storage->load($added_paragraph_data['target']);
+        if (!$added_paragraph instanceof ParagraphInterface) {
           continue;
         }
 
-        $duplicateParagraph = $new_paragraph->addTranslation($lang);
+        $duplicateParagraph = $added_paragraph->addTranslation($lang);
 
         $paragraph_reference = [
           'target_id' => $duplicateParagraph->id(),
@@ -108,7 +107,7 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
         ];
 
         // Set the paragraph in correct position.
-        $paragraph_position = $added_paragraph['delta'];
+        $paragraph_position = $added_paragraph_data['delta'];
         $this->insertItemAtPosition($translated_paragraphs, $paragraph_reference, $paragraph_position);
       }
 

--- a/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
+++ b/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\infofinland_common\Plugin\QueueWorker;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Drupal\paragraphs\ParagraphInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Copy paragraphs from fi-content to other languages.
+ *
+ * @QueueWorker(
+ *   id = "paragraph_copy_worker",
+ *   title = @Translation("Paragraph copy worker"),
+ *   cron = {"time" = 60}
+ * )
+ */
+final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFactoryPluginInterface {
+
+  /**
+   * The constructor.
+   *
+   * @param array $configuration
+   *   Configuration array.
+   * @param mixed $plugin_id
+   *   The plugin id.
+   * @param mixed $plugin_definition
+   *   The plugin definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
+   *   The entity type manager.
+   */
+  public function __construct(
+    array $configuration,
+          $plugin_id,
+          $plugin_definition,
+    protected EntityTypeManagerInterface $entityTypeManager,
+  ) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) : self {
+    return new self(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+
+  public function processItem($data): void {
+    if (!isset($data['nid']) || !isset($data['data'])) {
+      return;
+    }
+
+    $nodeStorage = $this->entityTypeManager->getStorage('node');
+
+    $nodeStorage->resetCache([$data['nid']]);
+    $entity = $nodeStorage->load($data['nid']);
+
+    $added_paragraphs = json_decode($data['data'], TRUE);
+
+    $entity_type_manager = \Drupal::entityTypeManager();
+    $paragraph_storage = $entity_type_manager->getStorage('paragraph');
+    $translation_languages = $entity->getTranslationLanguages();
+
+    foreach ($translation_languages as $language) {
+      $lang = $language->getId();
+      if ($lang === 'fi' || !$entity->hasTranslation($lang)) {
+        continue;
+      }
+
+      // The translation is set as a draft when paragraphs are copied.
+      // The last revision must be explicitly fetched to prevent data loss.
+      $node_translation = $entity->getTranslation($lang);
+      if (!$node_translation->isLatestTranslationAffectedRevision()) {
+        $latest_revision_id = $nodeStorage
+          ->getLatestTranslationAffectedRevisionId($entity->id(), $lang);
+
+        $node_translation = $nodeStorage->loadRevision($latest_revision_id);
+        $node_translation = $node_translation->getTranslation($lang);
+      }
+
+      $translated_paragraphs = $node_translation->get('field_content')->getValue();
+
+      foreach ($added_paragraphs as $added_paragraph) {
+        $new_paragraph = $paragraph_storage->load($added_paragraph['target']);
+        if (!$new_paragraph instanceof ParagraphInterface) {
+          continue;
+        }
+
+        $duplicateParagraph = $new_paragraph->addTranslation($lang);
+
+        $paragraph_reference = [
+          'target_id' => $duplicateParagraph->id(),
+          'target_revision_id' => $duplicateParagraph->getRevisionId(),
+        ];
+
+        // Set the paragraph in correct position.
+        $paragraph_position = $added_paragraph['delta'];
+        $this->insertItemAtPosition($translated_paragraphs, $paragraph_reference, $paragraph_position);
+      }
+
+      /** @var \Drupal\Core\Entity\ContentEntityStorageInterface $storage */
+      $storage = \Drupal::entityTypeManager()->getStorage($node_translation->getEntityTypeId());
+      $node_translation = $storage->createRevision($node_translation, $node_translation->isDefaultRevision());
+
+      $node_translation->set('moderation_state', 'draft');
+      $node_translation->field_content = $translated_paragraphs;
+
+      if ($node_translation instanceof RevisionLogInterface) {
+        $node_translation->setRevisionLogMessage('New content added for finnish page and copied to translations');
+        $node_translation->setRevisionUserId($entity->getOwnerId());
+      }
+      $node_translation->save();
+    }
+  }
+
+
+  /**
+   * Insert an item on any position in multidimensional array while preserving the order.
+   *
+   * @param array $array
+   *   The array we are modifying.
+   * @param array $insert
+   *   The content we want to add into the array.
+   * @param int $position
+   *   The position where the content is inserted.
+   */
+  private function insertItemAtPosition(array &$array, array $insert, int $position) {
+    if (count($array) === 1)  {
+      $array[] = $insert;
+      return;
+    }
+
+    $remains = array_slice($array, max(0, $position));
+    $array = array_merge(
+      array_slice($array, 0, $position),
+      [$insert],
+      $remains
+    );
+  }
+
+}


### PR DESCRIPTION
# [UHF-10742](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10742)
Prevent page save from dying by moving the paragraph-copier to queue

## What was done
Created queue to handle paragraph copying between translations.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10742`
  * `make fresh`
* Run `make drush-cr`

## How to test
Try coming up with different ways to break the feature here's a few.

Few things about the copy-feature:
- The copying only directly affects the paragraphs which were added to finnish node
- If paragraphs were added to translations, the copying tool won't be able to take them into account.
  - The copied paragraphs try to follow the finnish translation as closely as possible. 

Notice: **Pay attention to the total count of added and copied paragraphs. The old implementation might have had a bug which causes data loss.**

- Create new page in finnish, save it without adding anything
  - Create an english translation and save it
- Add a couple of paragraphs to the finnish node's field_content and save the node
- run `drush:queue-run paragraph_copy_worker`

Go check the english translation and see that the new paragraphs were created and the node is set to draft

- Add more paragraphs to the finnish node's field_content and save the node
- run `drush:queue-run paragraph_copy_worker`

Go check the english translation and see that the new paragraphs were created and the node is set to draft

- Add more paragraphs to the finnish node's field_content
  - This time, reorder the newly added paragraphs and save the node 
- run `drush:queue-run paragraph_copy_worker`

Go check the english translation and see that the new paragraphs were created and check that the node is saved as draft

- Set the english translation to published, add few paragraphs and save it.
- Add more paragraphs to the finnish node's field_content and save the node
- run `drush:queue-run paragraph_copy_worker`
- Go check the english translation
  - The paragraphs' order should be quite close to the finnish one(not exactly)
  - The paragraph count should match  

Try removing and adding paragraphs at the same time
Try adding all translations and create 5-10 paragraphs.
Try editing existing nodes.


[UHF-10742]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10742?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ