### PR TITLE
UHF-10657: Show row weights

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,9 @@
                 "PoStreamReader::readLine() throws an error on module install (https://drupal.org/i/3301239)": "https://www.drupal.org/files/issues/2023-01-17/drupal_core-PoStreamReader_readLine_throws_an_error_on_module_install-3301239-7.patch",
                 "Cannot save or publish originating node or translations (https://drupal.org/i/3285657)": "https://www.drupal.org/files/issues/2022-06-14/core9.2-node-lock-translations-2744851.patch"
             },
+            "drupal/gin": {
+                "Fix Gin row weights. (https://www.drupal.org/project/gin/issues/3461093)": "./patches/gin_row_weights-3461093.patch"
+            },
             "drupal/paragraphs": {
                 "[#UHF-2059] Enhancements for the Admin UI": "https://raw.githubusercontent.com/City-of-Helsinki/drupal-helfi-platform-config/fdccb32397cc6fa19b4d0077b21a2b18aa6be297/patches/helfi_customizations_for_paragraphs_widget_8.x-1.12.patch"
             },

--- a/patches/gin_row_weights-3461093.patch
+++ b/patches/gin_row_weights-3461093.patch
@@ -1,0 +1,14 @@
+diff --git a/js/overrides/tabledrag.js b/js/overrides/tabledrag.js
+index 2462c081f..16dd901f7 100644
+--- a/js/overrides/tabledrag.js
++++ b/js/overrides/tabledrag.js
+@@ -253,7 +253,8 @@
+         this.toggleColumns();
+       }.bind(this),
+     );
+-    if ($table.parents('.gin-table-scroll-wrapper')) {
++
++    if ($table.parents('.gin-table-scroll-wrapper').length > 0) {
+       $table.parents('.gin-table-scroll-wrapper').before($toggleWeightWrapper);
+     }
+     else {


### PR DESCRIPTION
# [UHF-10657](https://helsinkisolutionoffice.atlassian.net/browse/UHF-10657)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added patch to fix the 'show row weights' button when dealing with paragraphs.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-10657`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the show row weights button has reappeared for the paragraph 
<img width="395" alt="image" src="https://github.com/user-attachments/assets/264b8aaa-bd9f-42f8-954b-d49bc2ca6030">

* [ ] Check that code follows our standards


[UHF-10657]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-10657?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ