### PR TITLE
node_translation not existing caused error

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -10,9 +10,11 @@ parameters:
   excludePaths:
     - vendor
   level: 3
-  checkMissingIterableValueType: false
   treatPhpDocTypesAsCertain: false
   ignoreErrors:
+    -
+      identifier: missingType.iterableValue
+      
     -
       message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
       count: 1

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -13,9 +13,6 @@ parameters:
   treatPhpDocTypesAsCertain: false
   ignoreErrors:
     -
-      identifier: missingType.iterableValue
-      
-    -
       message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
       count: 1
       path: public/modules/custom/infofinland_admin_tools/src/Controller/ListController.php
@@ -189,26 +186,6 @@ parameters:
       message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\EntityInterface\\:\\:setRevisionCreationTime\\(\\)\\.$#"
       count: 1
       path: public/modules/custom/infofinland_common/src/Plugin/ContentCombiner.php
-
-    -
-      message: "#^Access to an undefined property Drupal\\\\Core\\\\Entity\\\\TranslatableRevisionableInterface\\:\\:\\$field_content\\.$#"
-      count: 1
-      path: public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
-
-    -
-      message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\RevisionableInterface\\:\\:getTranslation\\(\\)\\.$#"
-      count: 1
-      path: public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
-
-    -
-      message: "#^Call to an undefined method Drupal\\\\Core\\\\Entity\\\\TranslatableRevisionableInterface\\:\\:set\\(\\)\\.$#"
-      count: 1
-      path: public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
-
-    -
-      message: "#^\\\\Drupal calls should be avoided in classes, use dependency injection instead$#"
-      count: 2
-      path: public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
 
     -
       message: "#^Access to an undefined property DOMNode\\:\\:\\$value\\.$#"

--- a/public/modules/custom/infofinland_common/infofinland_common.install
+++ b/public/modules/custom/infofinland_common/infofinland_common.install
@@ -149,6 +149,13 @@ function infofinland_common_update_9008(): void {
 
   foreach ($langcodes as $langcode) {
     $node = $storage->load($node_id);
+    if (
+      !$node ||
+      !$node->hasTranslation($langcode)
+    ) {
+      continue;
+    }
+
     $node = $node->getTranslation($langcode);
     $revision = $storage->createRevision($node);
     // @phpstan-ignore-next-line

--- a/public/modules/custom/infofinland_common/infofinland_common.install
+++ b/public/modules/custom/infofinland_common/infofinland_common.install
@@ -7,6 +7,10 @@
 
 declare(strict_types=1);
 
+use Drupal\Core\Entity\EntityInterface;
+use Drupal\Core\Entity\ContentEntityBase;
+use Drupal\Core\Entity\EntityTypeInterface;
+
 /**
  * Handle filter token.
  */
@@ -151,6 +155,7 @@ function infofinland_common_update_9008(): void {
     $node = $storage->load($node_id);
     $node = $node->getTranslation($langcode);
     $revision = $storage->createRevision($node);
+    // @phpstan-ignore-next-line
     $revision->set('moderation_state', 'draft');
     $revision->save();
   }

--- a/public/modules/custom/infofinland_common/infofinland_common.install
+++ b/public/modules/custom/infofinland_common/infofinland_common.install
@@ -7,10 +7,6 @@
 
 declare(strict_types=1);
 
-use Drupal\Core\Entity\EntityInterface;
-use Drupal\Core\Entity\ContentEntityBase;
-use Drupal\Core\Entity\EntityTypeInterface;
-
 /**
  * Handle filter token.
  */

--- a/public/modules/custom/infofinland_common/infofinland_common.install
+++ b/public/modules/custom/infofinland_common/infofinland_common.install
@@ -147,8 +147,8 @@ function infofinland_common_update_9008(): void {
   $langcodes = ['en', 'sv'];
   $storage = \Drupal::entityTypeManager()->getStorage('node');
 
-  foreach($langcodes as $langcode) {
-    $node = $storage->load(39828);
+  foreach ($langcodes as $langcode) {
+    $node = $storage->load($node_id);
     $node = $node->getTranslation($langcode);
     $revision = $storage->createRevision($node);
     $revision->moderation_state->value = 'draft';

--- a/public/modules/custom/infofinland_common/infofinland_common.install
+++ b/public/modules/custom/infofinland_common/infofinland_common.install
@@ -138,3 +138,20 @@ function infofinland_common_update_9006(): void {
  */
 function infofinland_common_update_9007(&$sandbox): void {
 }
+
+/**
+ * Create the missing revisions for a node.
+ */
+function infofinland_common_update_9008(): void {
+  $node_id = 39828;
+  $langcodes = ['en', 'sv'];
+  $storage = \Drupal::entityTypeManager()->getStorage('node');
+
+  foreach($langcodes as $langcode) {
+    $node = $storage->load(39828);
+    $node = $node->getTranslation($langcode);
+    $revision = $storage->createRevision($node);
+    $revision->moderation_state->value = 'draft';
+    $revision->save();
+  }
+}

--- a/public/modules/custom/infofinland_common/infofinland_common.install
+++ b/public/modules/custom/infofinland_common/infofinland_common.install
@@ -151,7 +151,7 @@ function infofinland_common_update_9008(): void {
     $node = $storage->load($node_id);
     $node = $node->getTranslation($langcode);
     $revision = $storage->createRevision($node);
-    $revision->moderation_state->value = 'draft';
+    $revision->set('moderation_state', 'draft');
     $revision->save();
   }
 }

--- a/public/modules/custom/infofinland_common/infofinland_common.services.yml
+++ b/public/modules/custom/infofinland_common/infofinland_common.services.yml
@@ -9,3 +9,7 @@ services:
     class: Drupal\infofinland_common\Routing\OAuthRouteSubscriber
     tags:
       - { name: event_subscriber }
+
+  logger.channel.infofinland_common:
+    parent: logger.channel_base
+    arguments: [ 'infofinland_common' ]

--- a/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
+++ b/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Drupal\infofinland_common\Plugin\QueueWorker;
 
+use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Entity\TranslatableInterface;
@@ -113,6 +114,7 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
         }
       }
 
+      assert($node_translation instanceof EntityInterface);
       $translated_paragraphs = $node_translation->get('field_content')->getValue();
 
       foreach ($added_paragraphs as $added_paragraph_data) {

--- a/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
+++ b/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
@@ -35,6 +35,7 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
    * @param \Psr\Log\LoggerInterface $logger
+   *   The logger.
    */
   public function __construct(
     array $configuration,

--- a/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
+++ b/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
@@ -8,8 +8,8 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
-use Drupal\Core\Utility\Error;
 use Drupal\paragraphs\ParagraphInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -34,12 +34,14 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
    *   The plugin definition.
    * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entityTypeManager
    *   The entity type manager.
+   * @param \Psr\Log\LoggerInterface $logger
    */
   public function __construct(
     array $configuration,
     $plugin_id,
     $plugin_definition,
     protected EntityTypeManagerInterface $entityTypeManager,
+    protected LoggerInterface $logger,
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
   }
@@ -53,6 +55,7 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
       $plugin_id,
       $plugin_definition,
       $container->get('entity_type.manager'),
+      $container->get('logger.channel.infofinland_common'),
     );
   }
 
@@ -96,12 +99,12 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
         else {
           $error = sprintf(
             'Paragraph copier cannot find translation for some reason.
-            Node id "%s" revision "%s" does not have a translation "%s".',
-            (string) $node_translation->id(),
+            Entity id "%s" revision "%s" langcode "%s".',
+            (string) $entity->id(),
             (string) $latest_revision_id,
             $lang
           );
-          \Drupal::logger('infofinland_common')->error($error);
+          $this->logger->error($error);
           continue;
         }
       }

--- a/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
+++ b/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php
@@ -6,6 +6,7 @@ namespace Drupal\infofinland_common\Plugin\QueueWorker;
 
 use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Entity\RevisionLogInterface;
+use Drupal\Core\Entity\TranslatableInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\paragraphs\ParagraphInterface;
@@ -93,16 +94,18 @@ final class ParagraphCopyWorker extends QueueWorkerBase implements ContainerFact
           ->getLatestTranslationAffectedRevisionId($entity->id(), $lang);
 
         $node_translation = $nodeStorage->loadRevision($latest_revision_id);
-
-        if ($node_translation && $node_translation->hasTranslation($lang)) {
+        if (
+          $node_translation instanceof TranslatableInterface &&
+          $node_translation->hasTranslation($lang)
+        ) {
           $node_translation = $node_translation->getTranslation($lang);
         }
         else {
           $error = sprintf(
             'Paragraph copier cannot find translation for some reason.
             Entity id "%s" revision "%s" langcode "%s".',
-            (string) $entity->id(),
-            (string) $latest_revision_id,
+            $entity->id(),
+            $latest_revision_id,
             $lang
           );
           $this->logger->error($error);


### PR DESCRIPTION
# [UHF-11298](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11298)

## What was done
- Prevent the error that can be found from cron pod (mentioned below).
- Update hook to recreate the missing revisions for node 39828

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11298`
  * `make fresh`
* Run `make drush-cr`

## How to test

- Go and edit en and sv translations of node 39828
- Edit page should load normally
- Saving the node works

Also
Check that the added check to ParagraphCopyWorker on line 91 prevents the worker from dying:

**Original error:** Error: Call to a member function getTranslation() on null in Drupal\infofinland_common\Plugin\QueueWorker\ParagraphCopyWorker->processItem() (line 91 of /var/www/html/public/modules/custom/infofinland_common/src/Plugin/QueueWorker/ParagraphCopyWorker.php) 



[UHF-11298]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ