### PR TITLE
UHF-11392: Linkkipankki permission problem

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -5185,7 +5185,7 @@
         },
         {
             "name": "drupal/infofinland_dummy",
-            "version": "dev-dev",
+            "version": "dev-UHF-11392",
             "dist": {
                 "type": "path",
                 "url": "./patches/helfi_platform_config",
@@ -16632,16 +16632,16 @@
         },
         {
             "name": "twig/twig",
-            "version": "v3.18.0",
+            "version": "v3.19.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "acffa88cc2b40dbe42eaf3a5025d6c0d4600cc50"
+                "reference": "d4f8c2b86374f08efc859323dbcd95c590f7124e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/acffa88cc2b40dbe42eaf3a5025d6c0d4600cc50",
-                "reference": "acffa88cc2b40dbe42eaf3a5025d6c0d4600cc50",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/d4f8c2b86374f08efc859323dbcd95c590f7124e",
+                "reference": "d4f8c2b86374f08efc859323dbcd95c590f7124e",
                 "shasum": ""
             },
             "require": {
@@ -16696,7 +16696,7 @@
             ],
             "support": {
                 "issues": "https://github.com/twigphp/Twig/issues",
-                "source": "https://github.com/twigphp/Twig/tree/v3.18.0"
+                "source": "https://github.com/twigphp/Twig/tree/v3.19.0"
             },
             "funding": [
                 {
@@ -16708,7 +16708,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-29T10:51:50+00:00"
+            "time": "2025-01-29T07:06:14+00:00"
         },
         {
             "name": "twistor/flysystem-stream-wrapper",

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -228,11 +228,6 @@ parameters:
       path: public/modules/custom/infofinland_permissions/infofinland_permissions.module
 
     -
-      message: "#^Variable \\$municipality_ids might not be defined\\.$#"
-      count: 1
-      path: public/modules/custom/infofinland_permissions/infofinland_permissions.module
-
-    -
       message: "#^Variable \\$icon_path in empty\\(\\) always exists and is not falsy\\.$#"
       count: 1
       path: public/themes/custom/infofinland/infofinland.theme

--- a/public/modules/custom/infofinland_permissions/infofinland_permissions.module
+++ b/public/modules/custom/infofinland_permissions/infofinland_permissions.module
@@ -114,7 +114,6 @@ function infofinland_permissions_views_pre_build(ViewExecutable $view) {
       $view->setArguments($args);
     }
     else {
-
       $user = User::load($current_user->id());
       $user_municipalities = $user->get('field_municipality')->isEmpty()
         ? []

--- a/public/modules/custom/infofinland_permissions/infofinland_permissions.module
+++ b/public/modules/custom/infofinland_permissions/infofinland_permissions.module
@@ -114,27 +114,16 @@ function infofinland_permissions_views_pre_build(ViewExecutable $view) {
       $view->setArguments($args);
     }
     else {
-      $args = [];
-      $terms = \Drupal::entityTypeManager()->getStorage('taxonomy_term')->loadByProperties([
-        'vid' => 'municipalitys',
-      ]);
-
-      foreach ($terms as $term) {
-        $municipality_ids[] = $term->id();
-      }
 
       $user = User::load($current_user->id());
       $user_municipalities = explode(', ', $user->get('field_municipality')->getString());
       // Allowed for everyone: Helsinki, Espoo,  Vantaa, Kauniainen.
-      $allowed_municipality_ids = array_unique(['1', '2', '3', '4', ...$user_municipalities]);
+      $allowed_municipality_ids = ['1','2','3','4'];
+      if (!empty($user_municipalities) && $user_municipalities[0] != "") {
+        $allowed_municipality_ids = array_merge($allowed_municipality_ids, $user_municipalities);
+      }
 
-      // Use exclude filtering to also show links without municipality.
-      // If the diff returns empty, we must return the municipality id list.
-      $args = !array_diff($municipality_ids, $allowed_municipality_ids)
-        ? $allowed_municipality_ids
-        : implode(',', array_diff($municipality_ids, $allowed_municipality_ids));
-
-      $view->setArguments($args);
+      $view->setArguments(array_unique($allowed_municipality_ids));
     }
   }
 

--- a/public/modules/custom/infofinland_permissions/infofinland_permissions.module
+++ b/public/modules/custom/infofinland_permissions/infofinland_permissions.module
@@ -120,12 +120,12 @@ function infofinland_permissions_views_pre_build(ViewExecutable $view) {
         : explode(',', $user->get('field_municipality')->getString());
 
       // Allowed for everyone: Helsinki, Espoo,  Vantaa, Kauniainen.
-      $allowed_municipality_ids = ['1','2','3','4'];
+      $allowed_municipality_ids = ['1', '2', '3', '4'];
       if ($user_municipalities) {
         $allowed_municipality_ids = array_merge($allowed_municipality_ids, $user_municipalities);
       }
 
-      $view->setArguments(array_unique($allowed_municipality_ids));
+      $view->setArguments($allowed_municipality_ids);
     }
   }
 

--- a/public/modules/custom/infofinland_permissions/infofinland_permissions.module
+++ b/public/modules/custom/infofinland_permissions/infofinland_permissions.module
@@ -127,8 +127,13 @@ function infofinland_permissions_views_pre_build(ViewExecutable $view) {
       $user_municipalities = explode(', ', $user->get('field_municipality')->getString());
       // Allowed for everyone: Helsinki, Espoo,  Vantaa, Kauniainen.
       $allowed_municipality_ids = array_unique(['1', '2', '3', '4', ...$user_municipalities]);
-      // Use exlude filtering to also show links without municipality.
-      $args[] = implode(',', array_diff($municipality_ids, $allowed_municipality_ids));
+
+      // Use exclude filtering to also show links without municipality.
+      // If the diff returns empty, we must return the municipality id list.
+      $args = !array_diff($municipality_ids, $allowed_municipality_ids)
+        ? $allowed_municipality_ids
+        : implode(',', array_diff($municipality_ids, $allowed_municipality_ids));
+
       $view->setArguments($args);
     }
   }

--- a/public/modules/custom/infofinland_permissions/infofinland_permissions.module
+++ b/public/modules/custom/infofinland_permissions/infofinland_permissions.module
@@ -116,10 +116,13 @@ function infofinland_permissions_views_pre_build(ViewExecutable $view) {
     else {
 
       $user = User::load($current_user->id());
-      $user_municipalities = explode(', ', $user->get('field_municipality')->getString());
+      $user_municipalities = $user->get('field_municipality')->isEmpty()
+        ? []
+        : explode(',', $user->get('field_municipality')->getString());
+
       // Allowed for everyone: Helsinki, Espoo,  Vantaa, Kauniainen.
       $allowed_municipality_ids = ['1','2','3','4'];
-      if (!empty($user_municipalities) && $user_municipalities[0] != "") {
+      if ($user_municipalities) {
         $allowed_municipality_ids = array_merge($allowed_municipality_ids, $user_municipalities);
       }
 

--- a/public/modules/custom/infofinland_permissions/infofinland_permissions.module
+++ b/public/modules/custom/infofinland_permissions/infofinland_permissions.module
@@ -108,25 +108,7 @@ function infofinland_permissions_views_pre_build(ViewExecutable $view) {
   }
 
   if ($view->id() === 'linkit') {
-    // Show all links for certain roles.
-    if (in_array('infofinland_user', $roles) || in_array('admin', $roles)) {
-      $args[] = 'all';
-      $view->setArguments($args);
-    }
-    else {
-      $user = User::load($current_user->id());
-      $user_municipalities = $user->get('field_municipality')->isEmpty()
-        ? []
-        : explode(',', $user->get('field_municipality')->getString());
-
-      // Allowed for everyone: Helsinki, Espoo,  Vantaa, Kauniainen.
-      $allowed_municipality_ids = ['1', '2', '3', '4'];
-      if ($user_municipalities) {
-        $allowed_municipality_ids = array_merge($allowed_municipality_ids, $user_municipalities);
-      }
-
-      $view->setArguments($allowed_municipality_ids);
-    }
+    $view->setArguments(['all']);
   }
 
   if ($view->id() === 'media_entity_browser' || $view->id() === 'media') {


### PR DESCRIPTION
# [UHF-11392](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11392)

User 52 would not be able to see linkkipankki when the user was connected to municipality id 7 (vaasa).
If user had municipality 7, the array diff would return [0 => ""], which caused 304.
If instead of [0 => ""] you would return [], the view would be empty but would render normally
If you would return [7], it would exclude all id 7 -links from the view.
If you return all allowed values [1,2,3,4,7], it shows all links and user may edit the links belonging under ID-7

Fix this by just showing all links for all users. Only user with proper municipality is allowed to edit the links.


## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11392`
  * `make fresh`
* Run `make drush-cr`

## How to test
- (You might want to login as admin and in incognito window user id 52.)
- Login as user 52 (use reset tfa -drush command if you cannot log in)
- Go see [linkkipankki](https://drupal-infofinland.docker.so/fi/admin/content/linkkipankki)
- You should see the links and edit vaasa-links
- If you remove the vaasa-municipality from the user and run drush cr:
  - you can still see the links but not edit them.


[UHF-11392]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11392?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ