### PR TITLE
UHF-11171: Infofinland config overrides

### DIFF
--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -55,6 +55,7 @@ module:
   image_style_quality: 0
   infofinland_admin_tools: 0
   infofinland_brokenlink_checker: 0
+  infofinland_config: 0
   infofinland_common: 0
   infofinland_permissions: 0
   infofinland_user_cancel: 0

--- a/conf/cmi/core.extension.yml
+++ b/conf/cmi/core.extension.yml
@@ -55,8 +55,8 @@ module:
   image_style_quality: 0
   infofinland_admin_tools: 0
   infofinland_brokenlink_checker: 0
-  infofinland_config: 0
   infofinland_common: 0
+  infofinland_config: 0
   infofinland_permissions: 0
   infofinland_user_cancel: 0
   jsonapi: 0

--- a/public/modules/custom/infofinland_config/config/rewrite/editor.editor.full_html.yml
+++ b/public/modules/custom/infofinland_config/config/rewrite/editor.editor.full_html.yml
@@ -1,0 +1,151 @@
+config_rewrite: replace
+uuid: 71738422-2a39-40c7-a1e0-8989b0711a35
+langcode: en
+status: true
+dependencies:
+  config:
+    - filter.format.full_html
+  module:
+    - ckeditor5
+_core:
+  default_config_hash: ugdwymSgCGFPKEgJ5z8jmQmqYze8oXVFgpsZYlqJxys
+format: full_html
+editor: ckeditor5
+settings:
+  toolbar:
+    items:
+      - bold
+      - italic
+      - strikethrough
+      - underline
+      - superscript
+      - subscript
+      - removeFormat
+      - heading
+      - '|'
+      - bulletedList
+      - numberedList
+      - '|'
+      - link
+      - helfiQuote
+      - insertTable
+      - helfiLanguageSelector
+      - specialCharacters
+      - '|'
+      - undo
+      - redo
+      - '|'
+      - sourceEditing
+  plugins:
+    ckeditor5_heading:
+      enabled_headings:
+        - heading2
+        - heading3
+        - heading4
+        - heading5
+        - heading6
+    ckeditor5_list:
+      properties:
+        reversed: false
+        startIndex: true
+      multiBlock: true
+    ckeditor5_paste_filter_pasteFilter:
+      enabled: true
+      filters:
+        -
+          enabled: true
+          weight: 0
+          search: '<o:p><\/o:p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 1
+          search: '(<[^>]*) (style="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: 2
+          search: '(<[^>]*) (face="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: 3
+          search: '(<[^>]*) (class="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: 4
+          search: '(<[^>]*) (valign="[^"]*")'
+          replace: $1
+        -
+          enabled: true
+          weight: 5
+          search: '<font[^>]*>'
+          replace: ''
+        -
+          enabled: true
+          weight: 6
+          search: '<\/font>'
+          replace: ''
+        -
+          enabled: true
+          weight: 7
+          search: '<span.*?>(.*?)<\/span>'
+          replace: $1
+        -
+          enabled: true
+          weight: 8
+          search: '<span(?![^>]*\b(?:dir|lang)="[^"]*")[^>]*>(.*?)<\/span>'
+          replace: $1
+        -
+          enabled: true
+          weight: 9
+          search: '<p><span lang="[^"]*"><\/span><\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 10
+          search: '<span lang="[^"]*"><\/span>'
+          replace: ''
+        -
+          enabled: true
+          weight: 11
+          search: '<p>&nbsp;<\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 12
+          search: '<p><\/p>'
+          replace: ''
+        -
+          enabled: true
+          weight: 13
+          search: '<b><\/b>'
+          replace: ''
+        -
+          enabled: true
+          weight: 14
+          search: '<i><\/i>'
+          replace: ''
+        -
+          enabled: true
+          weight: 15
+          search: '<a name="OLE_LINK[^"]*">(.*?)<\/a>'
+          replace: $1
+        -
+          enabled: true
+          weight: 16
+          search: '<a name="[^"]*">(.*?)<\/a>'
+          replace: $1
+    ckeditor5_sourceEditing:
+      allowed_tags:
+        - '<figure tabindex>'
+        - '<figcaption>'
+    helfi_ckeditor_helfi_link:
+      helfi_link_attributes:
+        - '<a data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank">'
+    linkit_extension:
+      linkit_enabled: true
+      linkit_profile: helfi
+image_upload:
+  status: false

--- a/public/modules/custom/infofinland_config/config/rewrite/filter.format.full_html.yml
+++ b/public/modules/custom/infofinland_config/config/rewrite/filter.format.full_html.yml
@@ -1,0 +1,90 @@
+config_rewrite: replace
+uuid: ea5c94b2-36a0-4e67-9dc2-6bc24b599792
+langcode: en
+status: true
+dependencies:
+  module:
+    - editor
+    - helfi_api_base
+    - linkit
+name: HTML
+format: full_html
+weight: 0
+filters:
+  editor_file_reference:
+    id: editor_file_reference
+    provider: editor
+    status: false
+    weight: -43
+    settings: {  }
+  filter_align:
+    id: filter_align
+    provider: filter
+    status: false
+    weight: -42
+    settings: {  }
+  filter_autop:
+    id: filter_autop
+    provider: filter
+    status: true
+    weight: -46
+    settings: {  }
+  filter_caption:
+    id: filter_caption
+    provider: filter
+    status: false
+    weight: -41
+    settings: {  }
+  filter_html:
+    id: filter_html
+    provider: filter
+    status: true
+    weight: -50
+    settings:
+      allowed_html: '<br> <p data-helfi-quote-text> <h2> <h3> <h4> <h5> <h6> <figure tabindex> <figcaption> <strong> <em> <u> <s> <sub> <sup> <a href data-hds-icon-start data-is-external data-protocol data-hds-component data-hds-variant rel target="_blank" data-entity-type data-entity-uuid data-entity-substitution> <ul> <ol start> <li> <table> <tr> <td rowspan colspan> <th rowspan colspan> <thead> <tbody> <tfoot> <caption> <span dir> <blockquote data-helfi-quote> <footer data-helfi-quote-author> <cite>'
+      filter_html_help: true
+      filter_html_nofollow: false
+  filter_html_escape:
+    id: filter_html_escape
+    provider: filter
+    status: false
+    weight: -44
+    settings: {  }
+  filter_html_image_secure:
+    id: filter_html_image_secure
+    provider: filter
+    status: false
+    weight: -40
+    settings: {  }
+  filter_htmlcorrector:
+    id: filter_htmlcorrector
+    provider: filter
+    status: true
+    weight: -45
+    settings: {  }
+  filter_image_lazy_load:
+    id: filter_image_lazy_load
+    provider: filter
+    status: true
+    weight: -42
+    settings: {  }
+  filter_url:
+    id: filter_url
+    provider: filter
+    status: true
+    weight: -49
+    settings:
+      filter_url_length: 120
+  helfi_link_converter:
+    id: helfi_link_converter
+    provider: helfi_api_base
+    status: true
+    weight: -10
+    settings: {  }
+  linkit:
+    id: linkit
+    provider: linkit
+    status: true
+    weight: -48
+    settings:
+      title: true

--- a/public/modules/custom/infofinland_config/infofinland_config.info.yml
+++ b/public/modules/custom/infofinland_config/infofinland_config.info.yml
@@ -1,0 +1,6 @@
+name: 'Infofinland Config'
+type: module
+description: 'Config overrides for Infofinland'
+core_version_requirement: ^10 || ^11
+dependencies:
+  - helfi_platform_config:helfi_platform_config


### PR DESCRIPTION
# [UHF-11171](https://helsinkisolutionoffice.atlassian.net/browse/UHF-11171)
<!-- What problem does this solve? -->

## What was done
<!-- Describe what was done -->

* Added and enabled Infofinland Config module to override default configurations.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-11171`
  * `make fresh`
* Run `make drush-cr`

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Check that the config overrides works
* [ ] Check that code follows our standards


[UHF-11171]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-11171?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ