### PR TITLE
UHF-12101:  Updating CSP frame-src directive to allow the frontend preview iframe

### DIFF
--- a/public/modules/custom/infofinland_common/infofinland_common.services.yml
+++ b/public/modules/custom/infofinland_common/infofinland_common.services.yml
@@ -1,4 +1,8 @@
 services:
+  _defaults:
+    autoconfigure: true
+    autowire: true
+
   infofinland_common.repositories.client:
     class: Drupal\infofinland_common\Repositories\ClientRepository
     decorates: simple_oauth.repositories.client
@@ -13,3 +17,6 @@ services:
   logger.channel.infofinland_common:
     parent: logger.channel_base
     arguments: [ 'infofinland_common' ]
+
+  Drupal\infofinland_common\EventSubscriber\CspEventSubscriber:
+    class: Drupal\infofinland_common\EventSubscriber\CspEventSubscriber

--- a/public/modules/custom/infofinland_common/src/EventSubscriber/CspEventSubscriber.php
+++ b/public/modules/custom/infofinland_common/src/EventSubscriber/CspEventSubscriber.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\infofinland_common\EventSubscriber;
+
+use Drupal\csp\CspEvents;
+use Drupal\csp\Event\PolicyAlterEvent;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Event subscriber for CSP policy alteration.
+ *
+ * @package Drupal\infofinland_common\EventSubscriber
+ */
+class CspEventSubscriber implements EventSubscriberInterface {
+
+  /**
+   * Constructor.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $configFactory
+   *   The config factory.
+   */
+  public function __construct(
+    private readonly ConfigFactoryInterface $configFactory,
+  ) {
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents(): array {
+    $events = [];
+
+    if (class_exists(CspEvents::class)) {
+      $events[CspEvents::POLICY_ALTER] = 'policyAlter';
+    }
+
+    return $events;
+  }
+
+  /**
+   * Alter CSP policies.
+   *
+   * @param \Drupal\csp\Event\PolicyAlterEvent $event
+   *   The policy alter event.
+   */
+  public function policyAlter(PolicyAlterEvent $event): void {
+    // Add frontend domain to allow iframe embedding.
+    $frontend_url = $this->configFactory->get('next.next_site.infofinland_ui')->get('base_url');
+    if ($frontend_url) {
+      $policy = $event->getPolicy();
+      if ($policy->hasDirective('frame-src')) {
+        $policy->appendDirective('frame-src', $frontend_url);
+      }
+    }
+  }
+
+}

--- a/public/modules/custom/infofinland_common/tests/src/Unit/EventSubscriber/CspEventSubscriberTest.php
+++ b/public/modules/custom/infofinland_common/tests/src/Unit/EventSubscriber/CspEventSubscriberTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\infofinland_common\Unit;
+
+use DG\BypassFinals;
+use Drupal\csp\Csp;
+use Drupal\csp\CspEvents;
+use Drupal\csp\Event\PolicyAlterEvent;
+use Drupal\infofinland_common\EventSubscriber\CspEventSubscriber;
+use Drupal\Tests\UnitTestCase;
+use Prophecy\PhpUnit\ProphecyTrait;
+use Prophecy\Prophecy\ObjectProphecy;
+use Drupal\Core\Config\ImmutableConfig;
+use Drupal\Core\Config\ConfigFactoryInterface;
+
+/**
+ * Unit tests for CspEventSubscriber.
+ *
+ * @group infofinland_common
+ * @coversDefaultClass \Drupal\infofinland_common\EventSubscriber\CspEventSubscriber
+ */
+class CspEventSubscriberTest extends UnitTestCase {
+
+  use ProphecyTrait;
+
+  /**
+   * The CspEventSubscriber.
+   *
+   * @var \Drupal\infofinland_common\EventSubscriber\CspEventSubscriber
+   */
+  protected CspEventSubscriber $cspEventSubscriber;
+
+  /**
+   * The Event.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected ObjectProphecy $event;
+
+  /**
+   * The Csp policy.
+   *
+   * @var \Prophecy\Prophecy\ObjectProphecy
+   */
+  protected ObjectProphecy $policy;
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function setUp(): void {
+    parent::setUp();
+    BypassFinals::enable();
+
+    $nextConfig = $this->prophesize(ImmutableConfig::class);
+    $nextConfig->get('base_url')->willReturn('https://www.infofinland.fi');
+    $config = $this->prophesize(ConfigFactoryInterface::class);
+    $config->get('next.next_site.infofinland_ui')->willReturn($nextConfig->reveal());
+
+    $this->event = $this->prophesize(PolicyAlterEvent::class);
+    $this->policy = $this->prophesize(Csp::class);
+    $this->event->getPolicy()->willReturn($this->policy->reveal());
+
+    $this->cspEventSubscriber = new CspEventSubscriber($config->reveal());
+  }
+
+  /**
+   * Tests the getSubscribedEvents method.
+   *
+   * @covers ::getSubscribedEvents
+   */
+  public function testGetSubscribedEvents(): void {
+    $this->assertEquals([CspEvents::POLICY_ALTER => 'policyAlter'], CspEventSubscriber::getSubscribedEvents());
+  }
+
+  /**
+   * Tests policy alteration.
+   *
+   * @covers ::policyAlter
+   */
+  public function testPolicyAlterWithLocalEnvironment(): void {
+    $this->policy->hasDirective('frame-src')->willReturn(TRUE);
+    $this->policy->appendDirective('frame-src', 'https://www.infofinland.fi')->shouldBeCalled();
+
+    $this->cspEventSubscriber->policyAlter($this->event->reveal());
+  }
+
+}


### PR DESCRIPTION
# [UHF-12101](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12101)
<!-- What problem does this solve? -->

Node view display includes an iframe with embedded frontend view of the page, which was broken due to a recently introduced CSP, which doesn't allow the frontend domain in an iframe.

## What was done
<!-- Describe what was done -->

* CSP updated to allow the frontend domain in an iframe.

## How to install

* Make sure your instance is up and running on correct branch.
  * `git checkout UHF-12101`
  * `make fresh`
* Run `make drush-cr`
* Make sure the frontend is running as well by following the instructions in https://github.com/City-of-Helsinki/infofinland-ui?tab=readme-ov-file#development

## How to test
<!-- Describe steps how to test the features, add as many steps as you want to be tested -->

* [ ] Go to https://drupal-infofinland.docker.so/fi/admin/content and click one of the pages. The page should have an iframe with the frontend view of the node embedded (console still shows an error `[Report Only] Refused to frame 'http://localhost:3000/' because ...`, but thats coming from the `Content-Security-Policy-Report-Only`-headers and doesn't actually block anything)
* [ ] Check that code follows our standards
