### PR TITLE
UHF-12632: Updating drupal/next to 2.0.1.

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -6443,17 +6443,17 @@
         },
         {
             "name": "drupal/next",
-            "version": "2.0.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/next.git",
-                "reference": "2.0.0"
+                "reference": "2.0.1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://ftp.drupal.org/files/projects/next-2.0.0.zip",
-                "reference": "2.0.0",
-                "shasum": "1a7b07042d72fbfafd105c639b2bff062311a099"
+                "url": "https://ftp.drupal.org/files/projects/next-2.0.1.zip",
+                "reference": "2.0.1",
+                "shasum": "d36a513b54267cbb03282f51e4e0835f3366ff84"
             },
             "require": {
                 "drupal/core": "^10 || ^11",
@@ -6474,8 +6474,8 @@
             "type": "drupal-module",
             "extra": {
                 "drupal": {
-                    "version": "2.0.0",
-                    "datestamp": "1739303969",
+                    "version": "2.0.1",
+                    "datestamp": "1764787542",
                     "security-coverage": {
                         "status": "covered",
                         "message": "Covered by Drupal's security advisory policy"
@@ -6490,6 +6490,10 @@
                 {
                     "name": "shadcn",
                     "homepage": "https://www.chapterthree.com"
+                },
+                {
+                    "name": "bojan_dev",
+                    "homepage": "https://www.drupal.org/user/2801849"
                 },
                 {
                     "name": "brianperry",
@@ -22801,5 +22805,5 @@
     "prefer-lowest": false,
     "platform": {},
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }


### PR DESCRIPTION
# [UHF-12632](https://helsinkisolutionoffice.atlassian.net/browse/UHF-12632)

## What was done
<!-- Describe what was done, f.e. fixed bug in accordion javascript. -->
* Updates `drupal/next` from 2.0.0 to 2.0.1 to resolve https://www.drupal.org/sa-contrib-2025-122
* Should be ok to leave CORS disabled as we don't have any direct fetch-calls from browser to Drupal; all requests are proxied through Next.js API routes: https://git.drupalcode.org/project/next/-/blob/2.x/CORS.md?ref_type=heads#do-you-need-cors 


[UHF-12632]: https://helsinkisolutionoffice.atlassian.net/browse/UHF-12632?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ